### PR TITLE
Add Ctrl-r to cycle repeat mode; fix duplicate albums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `Ctrl-r` to cycle repeat mode
+
 ## [0.0.2] - 2019-09-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Add `Ctrl-r` to cycle repeat mode
+- Fix duplicate albums showing in artist discographies
 
 ## [0.0.2] - 2019-09-17
 

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ This table shows all that is possible with the Spotify API, what is implemented 
 | next_track                                        | No               | Skip User’s Playback To Next Track                                                                                                                           | Yes        |
 | previous_track                                    | No               | Skip User’s Playback To Previous Track                                                                                                                       | Yes        |
 | seek_track                                        | No               | Seek To Position In Currently Playing Track                                                                                                                  | Yes        |
-| repeat                                            | No               | Set Repeat Mode On User’s Playback                                                                                                                           | Yes        |
+| repeat                                            | Yes              | Set Repeat Mode On User’s Playback                                                                                                                           | Yes        |
 | volume                                            | No               | Set Volume For User’s Playback                                                                                                                               | No         |
-| shuffle                                           | No               | Toggle Shuffle For User’s Playback                                                                                                                           | Yes        |
+| shuffle                                           | Yes              | Toggle Shuffle For User’s Playback                                                                                                                           | Yes        |
 
 [spotify-dev]: https://developer.spotify.com/dashboard/applications

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ use rspotify::spotify::model::search::{
     SearchAlbums, SearchArtists, SearchPlaylists, SearchTracks,
 };
 use rspotify::spotify::model::track::{FullTrack, SavedTrack, SimplifiedTrack};
-use rspotify::spotify::senum::RepeatState;
+use rspotify::spotify::senum::{Country, RepeatState};
 use std::time::Instant;
 use tui::layout::Rect;
 
@@ -216,6 +216,7 @@ pub struct App {
     pub spotify: Option<Spotify>,
     pub track_table: TrackTable,
     pub album_list_index: usize,
+    pub country: Country,
 }
 
 impl App {
@@ -268,6 +269,7 @@ impl App {
                 offset: None,
             },
             instant_since_last_current_playback_poll: Instant::now(),
+            country: Country::UnitedKingdom, // TODO: This should be definable by the user
         }
     }
 
@@ -617,7 +619,7 @@ impl App {
             match spotify.artist_albums(
                 artist_id,
                 None,
-                None,
+                Some(self.country.clone()),
                 Some(self.large_search_limit),
                 Some(0),
             ) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -595,7 +595,8 @@ impl App {
     }
 
     pub fn repeat(&mut self) {
-        if let (Some(spotify), Some(context)) = (&self.spotify, &mut self.current_playback_context) {
+        if let (Some(spotify), Some(context)) = (&self.spotify, &mut self.current_playback_context)
+        {
             let next_repeat_state = match context.repeat_state {
                 RepeatState::Off => RepeatState::Context,
                 RepeatState::Context => RepeatState::Track,

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -31,7 +31,12 @@ pub fn handler(key: Key, app: &mut App) {
         Key::Char('\n') => {
             if let Some(spotify) = app.spotify.clone() {
                 // Can I run these functions in parellel?
-                match spotify.search_track(&app.input, app.small_search_limit, 0, Some(app.country.clone())) {
+                match spotify.search_track(
+                    &app.input,
+                    app.small_search_limit,
+                    0,
+                    Some(app.country.clone()),
+                ) {
                     Ok(result) => {
                         app.track_table.tracks = result.tracks.items.clone();
                         app.search_results.tracks = Some(result);

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -1,5 +1,4 @@
 use super::super::app::{ActiveBlock, App, RouteId};
-use rspotify::spotify::senum::Country;
 use std::convert::TryInto;
 use termion::event::Key;
 
@@ -31,11 +30,8 @@ pub fn handler(key: Key, app: &mut App) {
         }
         Key::Char('\n') => {
             if let Some(spotify) = app.spotify.clone() {
-                // TODO: This should be definable by the user
-                let country = Some(Country::UnitedKingdom);
-
                 // Can I run these functions in parellel?
-                match spotify.search_track(&app.input, app.small_search_limit, 0, country) {
+                match spotify.search_track(&app.input, app.small_search_limit, 0, Some(app.country.clone())) {
                     Ok(result) => {
                         app.track_table.tracks = result.tracks.items.clone();
                         app.search_results.tracks = Some(result);
@@ -49,7 +45,7 @@ pub fn handler(key: Key, app: &mut App) {
                     &app.input,
                     app.small_search_limit,
                     0,
-                    Some(Country::UnitedKingdom),
+                    Some(app.country.clone()),
                 ) {
                     Ok(result) => {
                         app.search_results.artists = Some(result);
@@ -63,7 +59,7 @@ pub fn handler(key: Key, app: &mut App) {
                     &app.input,
                     app.small_search_limit,
                     0,
-                    Some(Country::UnitedKingdom),
+                    Some(app.country.clone()),
                 ) {
                     Ok(result) => {
                         app.search_results.albums = Some(result);
@@ -77,7 +73,7 @@ pub fn handler(key: Key, app: &mut App) {
                     &app.input,
                     app.small_search_limit,
                     0,
-                    Some(Country::UnitedKingdom),
+                    Some(app.country.clone()),
                 ) {
                     Ok(result) => {
                         app.search_results.playlists = Some(result);

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,9 @@ fn main() -> Result<(), failure::Error> {
                                 Key::Ctrl('s') => {
                                     app.shuffle();
                                 }
+                                Key::Ctrl('r') => {
+                                    app.repeat();
+                                }
                                 Key::Char('/') => {
                                     app.set_current_route_state(
                                         Some(ActiveBlock::Input),

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -2,7 +2,8 @@ pub fn get_help_docs() -> Vec<Vec<&'static str>> {
     vec![
         vec!["General", "a", "Jump to currently playing album"],
         vec!["General", "s", "Save track"],
-        vec!["General", "<Ctrl+s>", "Toggle Shuffle"],
+        vec!["General", "<Ctrl+s>", "Toggle shuffle"],
+        vec!["General", "<Ctrl+r>", "Cycle repeat mode"],
         vec!["General", "h | <Left Arrow Key>", "Move selection left"],
         vec![
             "General",

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,6 +5,7 @@ use super::app::{
 };
 use super::banner::BANNER;
 use help::get_help_docs;
+use rspotify::spotify::senum::RepeatState;
 use tui::backend::Backend;
 use tui::layout::{Constraint, Direction, Layout, Rect};
 use tui::style::{Color, Modifier, Style};
@@ -518,9 +519,15 @@ where
                 "Off"
             };
 
+            let repeat_text = match current_playback_context.repeat_state {
+                RepeatState::Off => "Off",
+                RepeatState::Track => "Track",
+                RepeatState::Context => "All",
+            };
+
             let title = format!(
-                "{} ({} | Shuffle: {})",
-                play_title, current_playback_context.device.name, shuffle_text
+                "{} ({} | Shuffle: {} | Repeat: {})",
+                play_title, current_playback_context.device.name, shuffle_text, repeat_text
             );
 
             Block::default()


### PR DESCRIPTION
Included a keybind for repeat modes, which cycles through Off -> All -> Track -> Off as in the Electron client. Interface has a small visual update to show the repeat status next to the shuffle status, seen [here](https://i.imgur.com/MYKgbRN.png). The keybind inherits from shuffle (both ctrl+first letter) which seems consistent to me, but feel free to change it if you see fit.

Also closes #17, which was caused by the client not choosing between different versions of the same album available to disjoint sets of countries. It's not a permanent fix though, as it just follows the example set in `input.rs` by always requesting the UK versions. It is a little more future-proof in that both now make requests according to a new `App::country` field, but it's still essentially hard-coded. New search results for queen seen [here](https://imgur.com/HC5Bb7X.png).