### PR TITLE
Keep format of highligted track when it is playing

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -931,24 +931,23 @@ fn draw_table<B>(
     let rows = items.iter().enumerate().map(|(i, item)| {
         // Show this ♥ if the song is liked
         let mut formatted_row = item.format.clone();
-        // First check if the item is under selection
-        if i == selected_index {
-            return Row::StyledData(formatted_row.into_iter(), selected_style);
-        }
+        let mut style = Style::default().fg(Color::White); // default styling
 
-        // Next check if the song should be highlighted because it is currently playing
+        // First check if the song should be highlighted because it is currently playing
         if let Some(_track_playing_index) = track_playing_index {
             if i == _track_playing_index {
                 formatted_row[0] = format!("|> {}", &formatted_row[0]);
-                return Row::StyledData(
-                    formatted_row.into_iter(),
-                    Style::default().fg(Color::Cyan).modifier(Modifier::BOLD),
-                );
+                style = Style::default().fg(Color::Cyan).modifier(Modifier::BOLD);
             }
         }
 
-        // Otherwise return default styling
-        Row::StyledData(formatted_row.into_iter(), Style::default().fg(Color::White))
+        // Next check if the item is under selection
+        if i == selected_index {
+            style = selected_style;
+        }
+
+        // Return row styled data
+        return Row::StyledData(formatted_row.into_iter(), style);
     });
 
     let (title, header_columns) = table_layout;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -947,7 +947,7 @@ fn draw_table<B>(
         }
 
         // Return row styled data
-        return Row::StyledData(formatted_row.into_iter(), style);
+        Row::StyledData(formatted_row.into_iter(), style)
     });
 
     let (title, header_columns) = table_layout;


### PR DESCRIPTION
Currently when a playing track is selected it loses it's format ("|>" prefix) and style.

Before
![spotify-tui-highlight-1](https://user-images.githubusercontent.com/45465572/66663552-3eb0fe80-ec4b-11e9-92be-12d55be6ec66.png)
![spotify-tui-highlight-2](https://user-images.githubusercontent.com/45465572/66663556-407ac200-ec4b-11e9-8390-dec51a22dbc6.png)

Fixed
![spotify-tui-highlight-new-1](https://user-images.githubusercontent.com/45465572/66663565-42448580-ec4b-11e9-9876-641f22cb67f1.png)
![spotify-tui-highlight-new-2](https://user-images.githubusercontent.com/45465572/66663569-42dd1c00-ec4b-11e9-9dc1-7d0575cc4f6c.png)
