### PR TITLE
Add a redirect_uri web server with basic webpage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Keep format of highlighted track when it is playing - [#44](https://github.com/Rigellute/spotify-tui/pull/44) thanks to [@jfaltis](https://github.com/jfaltis)
+- Start a web server on localhost to display a simple webpage for the Redirect URI. Should hopefully improve the onboarding experience.
 
 ## [0.0.5] - 2019-10-11
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ But here they are again:
 1. Go to the [Spotify dashboard](https://developer.spotify.com/dashboard/applications)
 1. Click `Create a Client ID` and create an app
 1. Now click `Edit Settings`
-1. Add `http://localhost:8888/callback` to the Redirect URIs - you don't need anything running on localhost, it will still work
+1. Add `http://localhost:8888/callback` to the Redirect URIs
 1. You are now ready to authenticate with Spotify!
 1. Go back to the terminal
 1. Run `spt`

--- a/redirect_uri.html
+++ b/redirect_uri.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>spotify-tui</title>
+    <link
+      href="https://fonts.googleapis.com/css?family=Roboto+Mono&display=swap"
+      rel="stylesheet"
+    />
+    <style type="text/css" media="screen">
+      * {
+        padding: 0;
+        margin: 0;
+      }
+
+      html {
+        color: #e6e6dc;
+        font-family: "Roboto Mono", monospace;
+      }
+
+      h1 {
+        font-size: 6rem;
+      }
+
+      .container {
+        height: 100vh;
+        background-color: #002635;
+        display: flex;
+        flex: 1;
+        justify-content: center;
+        align-items: center;
+      }
+
+      .lead {
+        margin-top: 1.6rem;
+        color: #77929e;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <h1>spotify-tui</h1>
+        <p class="lead">Copy the URL of this page into the terminal</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,7 +101,7 @@ impl ClientConfig {
                "Go to the Spotify dashboard - https://developer.spotify.com/dashboard/applications",
                "Click `Create a Client ID` and create an app",
                "Now click `Edit Settings`",
-               &format!("Add `{}` to the Redirect URIs - you don't need anything running on localhost", LOCALHOST),
+               &format!("Add `{}` to the Redirect URIs", LOCALHOST),
                "You are now ready to authenticate with Spotify!",
             ];
 

--- a/src/redirect_uri.rs
+++ b/src/redirect_uri.rs
@@ -1,0 +1,48 @@
+use std::fs;
+use std::io::prelude::*;
+use std::net::TcpListener;
+use std::net::TcpStream;
+use std::sync::mpsc::{Receiver, TryRecvError};
+
+pub fn redirect_uri_web_server(thread_reciever: Receiver<()>) {
+    let listener = TcpListener::bind("127.0.0.1:8888");
+
+    match listener {
+        Ok(listener) => {
+            for stream in listener.incoming() {
+                match stream {
+                    Ok(stream) => {
+                        handle_connection(stream);
+
+                        // Listen for any signal to break out of this loop and close the server
+                        match thread_reciever.try_recv() {
+                            Ok(_) | Err(TryRecvError::Disconnected) => {
+                                break;
+                            }
+                            Err(TryRecvError::Empty) => {}
+                        }
+                    }
+                    Err(e) => {
+                        println!("Error running redirect uri webserver {}", e);
+                    }
+                };
+            }
+        }
+        Err(e) => {
+            println!("Error running redirect uri webserver {}", e);
+        }
+    }
+}
+
+fn handle_connection(mut stream: TcpStream) {
+    // The request will be quite large (> 512) so just assign plenty just in case
+    let mut buffer = [0; 1000];
+    stream.read_exact(&mut buffer).unwrap();
+
+    let contents = fs::read_to_string("redirect_uri.html").unwrap();
+
+    let response = format!("HTTP/1.1 200 OK\r\n\r\n{}", contents);
+
+    stream.write_all(response.as_bytes()).unwrap();
+    stream.flush().unwrap();
+}


### PR DESCRIPTION
Based on feedback, some people found it confusing that the redirect URI landed you on local with non existent web server (basically a blank page).

It felt like something went wrong during setup.

This PR attempts to remove that confusion by displaying a very simple webpage, which will then get shutdown once auth is successful. 