### PR TITLE
Add OpenSSL dependency in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ If you want to play tracks, Spotify requires that you have a Premium account.
 
 ## Development
 
+1. [Install OpenSSL](https://docs.rs/openssl/0.10.25/openssl/#automatic)
 1. [Install Rust](https://www.rust-lang.org/tools/install)
 1. Clone or fork this repo and `cd` to it
 1. And then `cargo run`


### PR DESCRIPTION
For building this project, OpenSSL needs to be installed.

In order for the OpenSSL installation to be automatically found, ```pkg-config``` is needed on Linux, ```homebrew``` on macOS and ```vcpkg``` on windows. 

I have added a link to the OpenSSL crate documentation that explains this.