### PR TITLE
Fix input errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement seek functionality - you can now use `<` to seek backwards 5 seconds and `>` to go forwards 5 seconds
 - The event `A` will jump to the album list of the first artist in the track's artists list - closing [#45](https://github.com/Rigellute/spotify-tui/issues/45)
 - Add volume controls - use `-` to decrease and `+` to increase volume in 10% increments. Closes [#57](https://github.com/Rigellute/spotify-tui/issues/57)
+- Search input bug: Fix "out-of-bounds" crash when pressing left too many times [#63](https://github.com/Rigellute/spotify-tui/issues/63)
+- Search input bug: Fix issue that backspace always deleted the end of input, not where the cursor was [#33](https://github.com/Rigellute/spotify-tui/issues/33)
 
 ## [0.0.5] - 2019-10-11
 

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -16,7 +16,7 @@ pub fn handler(key: Key, app: &mut App) {
             app.input_cursor_position = 0;
         }
         Key::Left => {
-            if !app.input.is_empty() {
+            if !app.input.is_empty() && app.input_cursor_position > 0 {
                 app.input_cursor_position -= 1;
             }
         }
@@ -99,8 +99,9 @@ pub fn handler(key: Key, app: &mut App) {
             app.input_cursor_position += 1;
         }
         Key::Backspace => {
-            if !app.input.is_empty() {
-                app.input.pop();
+            if !app.input.is_empty() && app.input_cursor_position > 0 {
+                app.input
+                    .remove((app.input_cursor_position - 1).try_into().unwrap());
                 app.input_cursor_position -= 1;
             }
         }


### PR DESCRIPTION
1. Fix "out-of-bounds" crash when pressing left too many times https://github.com/Rigellute/spotify-tui/issues/63
2. Fix issue that backspace always deleted the end of input, not where the cursor is https://github.com/Rigellute/spotify-tui/issues/33