### PR TITLE
Add artists view

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ The goal is to eventually implement almost every Spotify feature.
 - See if a song is liked
 - Be able to scroll through result pages in every view
 - View Library "Made for you"
-- View Library "Artists"
 - Make the play bar hoverable with its own event handlers that would
   - Like the playing song
   - Navigate to song info
@@ -178,7 +177,7 @@ This table shows all that is possible with the Spotify API, what is implemented 
 | current_user_followed_artists                     | No               | Gets a list of the artists followed by the current authorized user                                                                                           | Yes        |
 | current_user_saved_tracks_delete                  | No               | Remove one or more tracks from the current user's "Your Music" library.                                                                                      | Yes        |
 | current_user_saved_tracks_contain                 | No               | Check if one or more tracks is already saved in the current Spotify user’s “Your Music” library.                                                             | Yes        |
-| current_user_saved_tracks_add                     | No               | Save one or more tracks to the current user's "Your Music" library.                                                                                          | Yes        |
+| current_user_saved_tracks_add                     | Yes              | Save one or more tracks to the current user's "Your Music" library.                                                                                          | Yes        |
 | current_user_top_artists                          | No               | Get the current user's top artists                                                                                                                           | Yes        |
 | current_user_top_tracks                           | No               | Get the current user's top tracks                                                                                                                            | Yes        |
 | current_user_recently_played                      | No               | Get the current user's recently played tracks                                                                                                                | Yes        |

--- a/src/handlers/artists.rs
+++ b/src/handlers/artists.rs
@@ -5,6 +5,29 @@ use termion::event::Key;
 pub fn handler(key: Key, app: &mut App) {
     match key {
         k if common_key_events::left_event(k) => common_key_events::handle_left_event(app),
+        k if common_key_events::down_event(k) => {
+            if let Some(artists) = &mut app.library.saved_artists.get_results(None) {
+                let next_index = common_key_events::on_down_press_handler(
+                    &artists.items,
+                    Some(app.artists_list_index),
+                );
+                app.artists_list_index = next_index;
+            }
+        }
+        k if common_key_events::up_event(k) => {
+            if let Some(artists) = &mut app.library.saved_artists.get_results(None) {
+                let next_index = common_key_events::on_up_press_handler(
+                    &artists.items,
+                    Some(app.artists_list_index),
+                );
+                app.artists_list_index = next_index;
+            }
+        }
+        Key::Char('\n') => {
+            let artists = app.artists.to_owned();
+            let artist = &artists[app.artists_list_index];
+            app.get_artist_albums(&artist.id.to_owned(), &artist.name.to_owned());
+        }
         _ => {}
     }
 }

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -68,7 +68,7 @@ pub fn handler(key: Key, app: &mut App) {
             }
             //  Artists,
             4 => {
-                app.push_navigation_stack(RouteId::Artists, ActiveBlock::Artists);
+                app.get_artists(None);
             }
             // Podcasts,
             5 => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,9 @@ use config::{ClientConfig, LOCALHOST};
 use redirect_uri::redirect_uri_web_server;
 use util::{Event, Events};
 
-const SCOPES: [&str; 8] = [
+const SCOPES: [&str; 9] = [
     "playlist-read-private",
+    "user-follow-read",
     "user-library-modify",
     "user-library-read",
     "user-modify-playback-state",

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -165,7 +165,7 @@ where
             draw_not_implemented_yet(f, app, chunks[1], ActiveBlock::MadeForYou, "Made For You");
         }
         RouteId::Artists => {
-            draw_not_implemented_yet(f, app, chunks[1], ActiveBlock::Artists, "Artists");
+            draw_artist_table(f, app, chunks[1]);
         }
         RouteId::Podcasts => {
             draw_not_implemented_yet(f, app, chunks[1], ActiveBlock::Podcasts, "Podcasts");
@@ -343,6 +343,40 @@ struct AlbumUI {
     selected_index: usize,
     items: Vec<TableItem>,
     title: String,
+}
+
+pub fn draw_artist_table<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
+where
+    B: Backend,
+{
+    let header = [TableHeader {
+        text: "Artist",
+        width: get_percentage_width(layout_chunk.width, 1.0),
+    }];
+
+    let current_route = app.get_current_route();
+    let highlight_state = (
+        current_route.active_block == ActiveBlock::Artists,
+        current_route.hovered_block == ActiveBlock::Artists,
+    );
+    let items = app
+        .artists
+        .iter()
+        .map(|item| TableItem {
+            id: item.id.clone(),
+            format: vec![item.name.to_owned()],
+        })
+        .collect::<Vec<TableItem>>();
+
+    draw_table(
+        f,
+        app,
+        layout_chunk,
+        ("Artists", &header),
+        &items,
+        app.artists_list_index,
+        highlight_state,
+    )
 }
 
 pub fn draw_album_table<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
@@ -603,7 +637,7 @@ If you are trying to play a track, please check that
         ),
         Text::styled("
 Hint: a playback device must be either an official spotify client or a light weight alternative such as spotifyd
-        ", 
+        ",
         Style::default().fg(Color::Yellow)),
         Text::styled(
             "\nPress <Esc> to return",


### PR DESCRIPTION
This adds the basic implementation for an artists view. I have not added pagination, in my opinion it is better to do this in a future commit or PR.

I have chosen to present the result in a table and not in a list because I would like to show the saved songs by the user per artist like the Spotify desktop application does. When an artist is selected, the user will be shown all albums of an artist, this should probably be filtered in another commit or PR.

![screenshot_2019-10-15-150745](https://user-images.githubusercontent.com/13982006/66836388-c1d69b00-ef50-11e9-8bfc-d6966bfe0bd6.png)
