### PR TITLE
Get country from user profile

### DIFF
--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -1,4 +1,5 @@
 use super::super::app::{ActiveBlock, App, RouteId};
+use rspotify::spotify::senum::Country;
 use std::convert::TryInto;
 use termion::event::Key;
 
@@ -29,13 +30,14 @@ pub fn handler(key: Key, app: &mut App) {
             app.set_current_route_state(Some(ActiveBlock::Empty), Some(ActiveBlock::Library));
         }
         Key::Char('\n') => {
-            if let Some(spotify) = app.spotify.clone() {
+            if let (Some(spotify), Some(user)) = (app.spotify.clone(), app.user.clone()) {
+                let country = Country::from_str(&user.country.unwrap_or_else(|| "".to_string()));
                 // Can I run these functions in parellel?
                 match spotify.search_track(
                     &app.input,
                     app.small_search_limit,
                     0,
-                    Some(app.country.clone()),
+                    country.to_owned(),
                 ) {
                     Ok(result) => {
                         app.track_table.tracks = result.tracks.items.clone();
@@ -50,7 +52,7 @@ pub fn handler(key: Key, app: &mut App) {
                     &app.input,
                     app.small_search_limit,
                     0,
-                    Some(app.country.clone()),
+                    country.to_owned(),
                 ) {
                     Ok(result) => {
                         app.search_results.artists = Some(result);
@@ -64,7 +66,7 @@ pub fn handler(key: Key, app: &mut App) {
                     &app.input,
                     app.small_search_limit,
                     0,
-                    Some(app.country.clone()),
+                    country.to_owned(),
                 ) {
                     Ok(result) => {
                         app.search_results.albums = Some(result);
@@ -74,12 +76,7 @@ pub fn handler(key: Key, app: &mut App) {
                     }
                 }
 
-                match spotify.search_playlist(
-                    &app.input,
-                    app.small_search_limit,
-                    0,
-                    Some(app.country.clone()),
-                ) {
+                match spotify.search_playlist(&app.input, app.small_search_limit, 0, country) {
                     Ok(result) => {
                         app.search_results.playlists = Some(result);
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,6 +235,8 @@ fn main() -> Result<(), failure::Error> {
                                 app.handle_error(e);
                             }
                         };
+
+                        app.get_user();
                     }
 
                     app.get_current_playback();


### PR DESCRIPTION
Country is used by Spotify to determine which songs can be played by an user. By using the country from the users profile, the user does not have to configure it by themselves and the user will not be surprised when a song is not able to play because they have configured another country then in there Spotify account settings.