### PR TITLE
Add CHANGELOG to home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 ## [Unreleased]
 
 - Implement library "Artists" view - [#67](https://github.com/Rigellute/spotify-tui/pull/67) thanks [@svenvNL](https://github.com/svenvNL). NOTE that this adds an additional scope (`user-follow-read`), so you'll be prompted to grant this new permissions when you upgrade.
@@ -70,3 +65,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `s` event to save a track from within the "Recently Played" view (eventually this should be everywhere)
 - Add `Ctrl-s` to toggle shuffle
 - Add the following journey: search -> select artist and see their albums -> select album -> go to album and play tracks
+
+# What is this?
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/src/app.rs
+++ b/src/app.rs
@@ -193,6 +193,7 @@ pub struct ArtistAlbums {
 pub struct App {
     instant_since_last_current_playback_poll: Instant,
     navigation_stack: Vec<Route>,
+    pub home_scroll: u16,
     pub client_config: ClientConfig,
     pub artists: Vec<FullArtist>,
     pub artist_albums: Option<ArtistAlbums>,
@@ -245,6 +246,7 @@ impl App {
             size: Rect::default(),
             selected_album: None,
             selected_album_full: None,
+            home_scroll: 0,
             library: Library {
                 saved_tracks: ScrollableResultPages::new(),
                 saved_albums: ScrollableResultPages::new(),

--- a/src/handlers/home.rs
+++ b/src/handlers/home.rs
@@ -2,9 +2,96 @@ use super::super::app::App;
 use super::common_key_events;
 use termion::event::Key;
 
+const LARGE_SCROLL: u16 = 10;
+const SMALL_SCROLL: u16 = 1;
+
 pub fn handler(key: Key, app: &mut App) {
     match key {
         k if common_key_events::left_event(k) => common_key_events::handle_left_event(app),
+        k if common_key_events::down_event(k) => {
+            app.home_scroll += SMALL_SCROLL;
+        }
+        k if common_key_events::up_event(k) => {
+            if app.home_scroll > 0 {
+                app.home_scroll -= SMALL_SCROLL;
+            }
+        }
+        Key::Ctrl('d') => {
+            app.home_scroll += LARGE_SCROLL;
+        }
+        Key::Ctrl('u') => {
+            if app.home_scroll > LARGE_SCROLL {
+                app.home_scroll -= LARGE_SCROLL;
+            } else {
+                app.home_scroll = 0;
+            }
+        }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn on_small_down_press() {
+        let mut app = App::new();
+
+        handler(Key::Down, &mut app);
+        assert_eq!(app.home_scroll, SMALL_SCROLL);
+
+        handler(Key::Down, &mut app);
+        assert_eq!(app.home_scroll, SMALL_SCROLL * 2);
+    }
+
+    #[test]
+    fn on_small_up_press() {
+        let mut app = App::new();
+
+        handler(Key::Up, &mut app);
+        assert_eq!(app.home_scroll, 0);
+
+        app.home_scroll = 1;
+
+        handler(Key::Up, &mut app);
+        assert_eq!(app.home_scroll, 0);
+
+        // Check that smashing the up button doesn't go to negative scroll (which would cause a crash)
+        handler(Key::Up, &mut app);
+        handler(Key::Up, &mut app);
+        handler(Key::Up, &mut app);
+        assert_eq!(app.home_scroll, 0);
+    }
+
+    #[test]
+    fn on_large_down_press() {
+        let mut app = App::new();
+
+        handler(Key::Ctrl('d'), &mut app);
+        assert_eq!(app.home_scroll, LARGE_SCROLL);
+
+        handler(Key::Ctrl('d'), &mut app);
+        assert_eq!(app.home_scroll, LARGE_SCROLL * 2);
+    }
+
+    #[test]
+    fn on_large_up_press() {
+        let mut app = App::new();
+
+        let scroll = 37;
+        app.home_scroll = scroll;
+
+        handler(Key::Ctrl('u'), &mut app);
+        assert_eq!(app.home_scroll, scroll - LARGE_SCROLL);
+
+        handler(Key::Ctrl('u'), &mut app);
+        assert_eq!(app.home_scroll, scroll - LARGE_SCROLL * 2);
+
+        // Check that smashing the up button doesn't go to negative scroll (which would cause a crash)
+        handler(Key::Ctrl('u'), &mut app);
+        handler(Key::Ctrl('u'), &mut app);
+        handler(Key::Ctrl('u'), &mut app);
+        assert_eq!(app.home_scroll, 0);
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -653,6 +653,7 @@ Hint: a playback device must be either an official spotify client or a light wei
     }
 
     Paragraph::new(playing_text.iter())
+        .wrap(true)
         .style(Style::default().fg(Color::White))
         .block(
             Block::default()
@@ -668,26 +669,47 @@ fn draw_home<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
 where
     B: Backend,
 {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(25), Constraint::Percentage(75)].as_ref())
+        .margin(2)
+        .split(layout_chunk);
+
     let current_route = app.get_current_route();
     let highlight_state = (
         current_route.active_block == ActiveBlock::Home,
         current_route.hovered_block == ActiveBlock::Home,
     );
-    let display_block = Block::default()
+
+    Block::default()
         .title("Welcome!")
         .borders(Borders::ALL)
         .title_style(get_color(highlight_state))
-        .border_style(get_color(highlight_state));
+        .border_style(get_color(highlight_state))
+        .render(f, layout_chunk);
 
-    let text = vec![
+    let change_log = include_str!("../../CHANGELOG.md");
+
+    let top_text = vec![
         Text::styled(BANNER, Style::default().fg(Color::LightCyan)),
         Text::raw("\nPlease report any bugs or missing features to https://github.com/Rigellute/spotify-tui"),
     ];
 
-    Paragraph::new(text.iter())
+    let bottom_text = vec![Text::raw(change_log)];
+
+    // Contains the banner
+    Paragraph::new(top_text.iter())
         .style(Style::default().fg(Color::White))
-        .block(display_block)
-        .render(f, layout_chunk);
+        .block(Block::default())
+        .render(f, chunks[0]);
+
+    // CHANGELOG
+    Paragraph::new(bottom_text.iter())
+        .style(Style::default().fg(Color::White))
+        .block(Block::default())
+        .wrap(true)
+        .scroll(app.home_scroll)
+        .render(f, chunks[1]);
 }
 
 fn draw_not_implemented_yet<B>(
@@ -715,6 +737,7 @@ fn draw_not_implemented_yet<B>(
     Paragraph::new(text.iter())
         .style(Style::default().fg(Color::White))
         .block(display_block)
+        .wrap(true)
         .render(f, layout_chunk);
 }
 
@@ -767,6 +790,7 @@ where
 
     Paragraph::new([Text::raw(device_instructions.join("\n"))].iter())
         .style(Style::default().fg(Color::White))
+        .wrap(true)
         .block(
             Block::default()
                 .borders(Borders::NONE)


### PR DESCRIPTION
The CHANGELOG is included at build time and is scrollable after
selecting the "home" block.

![Screenshot 2019-10-18 at 19 57 55](https://user-images.githubusercontent.com/12150276/67120663-a635f380-f1e1-11e9-8ed9-3aeb4ad09282.png)


Closes https://github.com/Rigellute/spotify-tui/issues/62