### PR TITLE
Make playbar selectable/hoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement library "Artists" view - [#67](https://github.com/Rigellute/spotify-tui/pull/67) thanks [@svenvNL](https://github.com/svenvNL). NOTE that this adds an additional scope (`user-follow-read`), so you'll be prompted to grant this new permissions when you upgrade.
 - Fix searching with non-english characters - [#30](https://github.com/Rigellute/spotify-tui/pull/30). Thanks to [@fangyi-zhou](https://github.com/fangyi-zhou)
 - Remove hardcoded country (was always set to UK). We now fetch the user to get their country. [#68](https://github.com/Rigellute/spotify-tui/pull/68). Thanks to [@svenvNL](https://github.com/svenvNL)
+- Save currently playing track - the playbar is now selectable/hoverable [#80](https://github.com/Rigellute/spotify-tui/pull/80)
 
 ## [0.0.6] - 2019-10-14
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -94,6 +94,7 @@ pub enum SearchResultBlock {
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum ActiveBlock {
+    PlayBar,
     AlbumTracks,
     AlbumList,
     Artist,

--- a/src/handlers/empty.rs
+++ b/src/handlers/empty.rs
@@ -13,25 +13,36 @@ pub fn handler(key: Key, app: &mut App) {
             ActiveBlock::Library => {
                 app.set_current_route_state(None, Some(ActiveBlock::MyPlaylists));
             }
-            ActiveBlock::MyPlaylists => {
-                // Go to player
-            }
-            ActiveBlock::AlbumTracks | ActiveBlock::Home | ActiveBlock::TrackTable => {
-                // Go to player
+            ActiveBlock::Artist
+            | ActiveBlock::AlbumList
+            | ActiveBlock::AlbumTracks
+            | ActiveBlock::Artists
+            | ActiveBlock::Home
+            | ActiveBlock::MadeForYou
+            | ActiveBlock::MyPlaylists
+            | ActiveBlock::RecentlyPlayed
+            | ActiveBlock::TrackTable => {
+                app.set_current_route_state(None, Some(ActiveBlock::PlayBar));
             }
             _ => {}
         },
-        k if common_key_events::up_event(k) => {
-            if let ActiveBlock::MyPlaylists = app.get_current_route().hovered_block {
+        k if common_key_events::up_event(k) => match app.get_current_route().hovered_block {
+            ActiveBlock::MyPlaylists => {
                 app.set_current_route_state(None, Some(ActiveBlock::Library));
             }
-        }
+            ActiveBlock::PlayBar => {
+                app.set_current_route_state(None, Some(ActiveBlock::MyPlaylists));
+            }
+            _ => {}
+        },
         k if common_key_events::left_event(k) => match app.get_current_route().hovered_block {
-            ActiveBlock::RecentlyPlayed
-            | ActiveBlock::AlbumTracks
+            ActiveBlock::Artist
             | ActiveBlock::AlbumList
-            | ActiveBlock::Artist
+            | ActiveBlock::AlbumTracks
+            | ActiveBlock::Artists
             | ActiveBlock::Home
+            | ActiveBlock::MadeForYou
+            | ActiveBlock::RecentlyPlayed
             | ActiveBlock::TrackTable => {
                 app.set_current_route_state(None, Some(ActiveBlock::Library));
             }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -10,6 +10,7 @@ mod home;
 mod input;
 mod library;
 mod made_for_you;
+mod playbar;
 mod playlist;
 mod podcasts;
 mod recently_played;
@@ -153,6 +154,9 @@ fn handle_block_events(key: Key, app: &mut App) {
         }
         ActiveBlock::Podcasts => {
             podcasts::handler(key, app);
+        }
+        ActiveBlock::PlayBar => {
+            playbar::handler(key, app);
         }
     }
 }

--- a/src/handlers/playbar.rs
+++ b/src/handlers/playbar.rs
@@ -1,0 +1,37 @@
+use super::super::app::{ActiveBlock, App};
+use super::common_key_events;
+use termion::event::Key;
+
+pub fn handler(key: Key, app: &mut App) {
+    match key {
+        k if common_key_events::up_event(k) => {
+            app.set_current_route_state(Some(ActiveBlock::Empty), Some(ActiveBlock::MyPlaylists));
+        }
+        Key::Char('s') => {
+            if let Some(playing_context) = &app.current_playback_context {
+                if let Some(track) = &playing_context.item {
+                    if let Some(id) = track.id.to_owned() {
+                        app.save_tracks(vec![id]);
+                    }
+                }
+            }
+        }
+        _ => {}
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn on_left_press() {
+        let mut app = App::new();
+        app.set_current_route_state(Some(ActiveBlock::PlayBar), Some(ActiveBlock::PlayBar));
+
+        handler(Key::Up, &mut app);
+        let current_route = app.get_current_route();
+        assert_eq!(current_route.active_block, ActiveBlock::Empty);
+        assert_eq!(current_route.hovered_block, ActiveBlock::MyPlaylists);
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -123,7 +123,7 @@ where
     draw_routes(f, app, parent_layout[1]);
 
     // Currently playing
-    draw_playing_block(f, app, parent_layout[2]);
+    draw_playbar(f, app, parent_layout[2]);
 }
 
 pub fn draw_routes<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
@@ -527,7 +527,7 @@ where
     )
 }
 
-pub fn draw_playing_block<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
+pub fn draw_playbar<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
 where
     B: Backend,
 {
@@ -568,11 +568,17 @@ where
                 current_playback_context.device.volume_percent
             );
 
+            let current_route = app.get_current_route();
+            let highlight_state = (
+                current_route.active_block == ActiveBlock::PlayBar,
+                current_route.hovered_block == ActiveBlock::PlayBar,
+            );
+
             Block::default()
                 .borders(Borders::ALL)
                 .title(&title)
-                .title_style(Style::default().fg(Color::Gray))
-                .border_style(Style::default().fg(Color::Gray))
+                .title_style(get_color(highlight_state))
+                .border_style(get_color(highlight_state))
                 .render(f, layout_chunk);
 
             Paragraph::new(


### PR DESCRIPTION
When selecting the playbar, you can press `s` to save the currently
playing track. 

This opens up more possibilities such as viewing current playing track information.