### PR TITLE
Lay foundation for indicating if a track is saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix searching with non-english characters - [#30](https://github.com/Rigellute/spotify-tui/pull/30). Thanks to [@fangyi-zhou](https://github.com/fangyi-zhou)
 - Remove hardcoded country (was always set to UK). We now fetch the user to get their country. [#68](https://github.com/Rigellute/spotify-tui/pull/68). Thanks to [@svenvNL](https://github.com/svenvNL)
 - Save currently playing track - the playbar is now selectable/hoverable [#80](https://github.com/Rigellute/spotify-tui/pull/80)
+- Lay foundation for showing if a track is saved. You can now see if the currently playing track is saved (indicated by ♥)
 
 ## [0.0.6] - 2019-10-14
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -581,6 +581,15 @@ where
                 .border_style(get_color(highlight_state))
                 .render(f, layout_chunk);
 
+            let track_name = if app
+                .liked_song_ids_set
+                .contains(&track_item.id.clone().unwrap_or_else(|| "".to_string()))
+            {
+                format!("♥ {}", &track_item.name)
+            } else {
+                track_item.name.clone()
+            };
+
             Paragraph::new(
                 [Text::styled(
                     create_artist_string(&track_item.artists),
@@ -590,7 +599,7 @@ where
             )
             .style(Style::default().fg(Color::White))
             .block(
-                Block::default().title(&track_item.name).title_style(
+                Block::default().title(&track_name).title_style(
                     Style::default()
                         .fg(Color::LightCyan)
                         .modifier(Modifier::BOLD),


### PR DESCRIPTION
This commit will show if the currently playing track is saved or not.

<img width="391" alt="Screenshot 2019-10-19 at 12 08 51" src="https://user-images.githubusercontent.com/12150276/67144182-e2159b00-f26b-11e9-8266-d34c5c00b283.png">

The idea here is to build a HashSet of saved track ids, to which UI components can simply look at to see if the track is saved or not.

As we fetch tracks around the app, we need to make an additional request to see if any are liked. 

So it should be pretty straightforward from here to add this to other views.