### PR TITLE
Add info about libssl and pkf-config requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ To update, run
 cargo install spotify-tui --force
 ```
 
+#### Note on Linux
+
+For compilation on Linux the development packages for `libssl` are required.
+In order to locate dependencies, the compilation also requires `pkg-config` to be installed.
+
 ### Manual
 
 1. Download the latest [binary](https://github.com/Rigellute/spotify-tui/releases) for your OS.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ cargo install spotify-tui --force
 #### Note on Linux
 
 For compilation on Linux the development packages for `libssl` are required.
+For basic installation instructions, see [install OpenSSL](https://docs.rs/openssl/0.10.25/openssl/#automatic).
 In order to locate dependencies, the compilation also requires `pkg-config` to be installed.
 
 ### Manual


### PR DESCRIPTION
It's quite annoying that the compilation fails and you don't know about this upfront. Therefore I added generic information about the requirements.