### PR TITLE
Unsave already saved songs with 's'

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -707,6 +707,33 @@ impl App {
         }
     }
 
+    pub fn toggle_save_track(&mut self, track_id: String) {
+        if let Some(spotify) = &self.spotify {
+            match spotify.current_user_saved_tracks_contains(&[track_id.clone()]) {
+                Ok(saved) => {
+                    if saved[0] {
+                        match spotify.current_user_saved_tracks_delete(&[track_id]) {
+                            Ok(()) => {}
+                            Err(e) => {
+                                self.handle_error(e);
+                            }
+                        }
+                    } else {
+                        match spotify.current_user_saved_tracks_add(&[track_id]) {
+                            Ok(()) => {}
+                            Err(e) => {
+                                self.handle_error(e);
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    self.handle_error(e);
+                }
+            }
+        };
+    }
+
     pub fn save_tracks(&mut self, track_ids: Vec<String>) {
         if let Some(spotify) = &self.spotify {
             match spotify.current_user_saved_tracks_add(&track_ids) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -711,7 +711,7 @@ impl App {
         if let Some(spotify) = &self.spotify {
             match spotify.current_user_saved_tracks_contains(&[track_id.clone()]) {
                 Ok(saved) => {
-                    if saved[0] {
+                    if saved.first() == Some(&true) {
                         match spotify.current_user_saved_tracks_delete(&[track_id]) {
                             Ok(()) => {}
                             Err(e) => {
@@ -727,19 +727,6 @@ impl App {
                         }
                     }
                 }
-                Err(e) => {
-                    self.handle_error(e);
-                }
-            }
-        };
-    }
-
-    // Currently unused but keep for future changes
-    #[allow(dead_code)]
-    pub fn save_tracks(&mut self, track_ids: Vec<String>) {
-        if let Some(spotify) = &self.spotify {
-            match spotify.current_user_saved_tracks_add(&track_ids) {
-                Ok(()) => {}
                 Err(e) => {
                     self.handle_error(e);
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -734,6 +734,8 @@ impl App {
         };
     }
 
+    // Currently unused but keep for future changes
+    #[allow(dead_code)]
     pub fn save_tracks(&mut self, track_ids: Vec<String>) {
         if let Some(spotify) = &self.spotify {
             match spotify.current_user_saved_tracks_add(&track_ids) {

--- a/src/handlers/album_tracks.rs
+++ b/src/handlers/album_tracks.rs
@@ -62,7 +62,7 @@ pub fn handler(key: Key, app: &mut App) {
                             .get(app.saved_album_tracks_index)
                         {
                             if let Some(track_id) = &selected_track.id {
-                                app.save_tracks(vec![track_id.clone()]);
+                                app.toggle_save_track(track_id.clone());
                             };
                         };
                     }

--- a/src/handlers/playbar.rs
+++ b/src/handlers/playbar.rs
@@ -11,7 +11,7 @@ pub fn handler(key: Key, app: &mut App) {
             if let Some(playing_context) = &app.current_playback_context {
                 if let Some(track) = &playing_context.item {
                     if let Some(id) = track.id.to_owned() {
-                        app.save_tracks(vec![id]);
+                        app.toggle_save_track(id);
                     }
                 }
             }

--- a/src/handlers/recently_played.rs
+++ b/src/handlers/recently_played.rs
@@ -29,7 +29,7 @@ pub fn handler(key: Key, app: &mut App) {
                     recently_played_result.items.get(app.recently_played.index)
                 {
                     if let Some(track_id) = &selected_track.track.id {
-                        app.save_tracks(vec![track_id.clone()]);
+                        app.toggle_save_track(track_id.clone());
                     };
                 };
             };


### PR DESCRIPTION
Pressing s now toggles the saved state of a song, which allows unsaving songs. Kept the old save_tracks despite it not being used for usage in future changes. 