### PR TITLE
Add keybinding config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,40 @@ The binary is named `spt`.
 
 When running `spotify-tui` press `?` to bring up a help menu that shows currently implemented key events and their actions.
 
+# Configuration
+
+A configuration file is located at `${HOME}/.config/spotify-tui/config.yml`
+(not to be confused with client.yml which handles spotify authentication)
+
+The following is a sample config.yml file:
+```yaml
+# Sample config file
+
+# Key stroke can be used if it only uses two keys:
+# ctrl-q works,
+# ctrl-alt-q doesn't.
+back: 'ctrl-q'
+
+jump_to_album: 'a'
+
+# Shift modifiers use a capital letter (also applies with other modifier keys
+# like ctrl-A)
+jump_to_artist_album: 'A'
+
+manage_devices: 'd'
+decrease_volume: '-'
+increase_volume: '+'
+toggle_playback: ' '
+seek_backwards: '<'
+seek_forwards: '>'
+next_track: 'n'
+previous_track: 'p'
+help: '?'
+shuffle: 's'
+repeat: 'r'
+search: '/'
+```
+
 ## Limitations
 
 This app uses the [Web API](https://developer.spotify.com/documentation/web-api/) from Spotify, which doesn't handle streaming itself. So you'll need either an official Spotify client open or a lighter weight alternative such as [spotifyd](https://github.com/Spotifyd/spotifyd).

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use super::config::ClientConfig;
+use super::user_config::UserConfig;
 use failure::err_msg;
 use rspotify::spotify::client::Spotify;
 use rspotify::spotify::model::album::{FullAlbum, SavedAlbum, SimplifiedAlbum};
@@ -197,6 +198,7 @@ pub struct App {
     navigation_stack: Vec<Route>,
     pub home_scroll: u16,
     pub client_config: ClientConfig,
+    pub user_config: UserConfig,
     pub artists: Vec<FullArtist>,
     pub artist_albums: Option<ArtistAlbums>,
     pub album_table_context: AlbumTableContext,
@@ -243,6 +245,7 @@ impl App {
             artists_list_index: 0,
             artists: vec![],
             artist_albums: None,
+            user_config: UserConfig::new(),
             client_config: Default::default(),
             saved_album_tracks_index: 0,
             recently_played: Default::default(),

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -38,7 +38,7 @@ pub fn handle_app(key: Key, app: &mut App) {
             }
         },
         // Jump to currently playing album
-        Key::Char('a') => {
+        _ if key == app.user_config.jump_to_album => {
             if let Some(current_playback_context) = &app.current_playback_context {
                 if let Some(full_track) = &current_playback_context.item.clone() {
                     app.get_album_tracks(full_track.album.clone());
@@ -47,7 +47,7 @@ pub fn handle_app(key: Key, app: &mut App) {
         }
         // Jump to currently playing artist's album list.
         // NOTE: this only finds the first artist of the song and jumps to their albums
-        Key::Char('A') => {
+        _ if key == app.user_config.jump_to_artist_album => {
             if let Some(current_playback_context) = &app.current_playback_context {
                 if let Some(playing_item) = &current_playback_context.item.clone() {
                     if let Some(artist) = playing_item.artists.first() {
@@ -58,42 +58,42 @@ pub fn handle_app(key: Key, app: &mut App) {
                 }
             };
         }
-        Key::Char('d') => {
+        _ if key == app.user_config.manage_devices => {
             app.handle_get_devices();
         }
-        Key::Char('-') => {
+        _ if key == app.user_config.decrease_volume => {
             app.decrease_volume();
         }
-        Key::Char('+') => {
+        _ if key == app.user_config.increase_volume => {
             app.increase_volume();
         }
         // Press space to toggle playback
-        Key::Char(' ') => {
+        _ if key == app.user_config.toggle_playback => {
             app.toggle_playback();
         }
-        Key::Char('<') => {
+        _ if key == app.user_config.seek_backwards => {
             app.seek_backwards();
         }
-        Key::Char('>') => {
+        _ if key == app.user_config.seek_forwards => {
             app.seek_forwards();
         }
-        Key::Char('n') => {
+        _ if key == app.user_config.next_track => {
             app.next_track();
         }
-        Key::Char('p') => {
+        _ if key == app.user_config.previous_track => {
             app.previous_track();
         }
-        Key::Char('?') => {
+        _ if key == app.user_config.help => {
             app.set_current_route_state(Some(ActiveBlock::HelpMenu), None);
         }
 
-        Key::Ctrl('s') => {
+        _ if key == app.user_config.shuffle => {
             app.shuffle();
         }
-        Key::Ctrl('r') => {
+        _ if key == app.user_config.repeat => {
             app.repeat();
         }
-        Key::Char('/') => {
+        _ if key == app.user_config.search => {
             app.set_current_route_state(Some(ActiveBlock::Input), Some(ActiveBlock::Input));
         }
         _ => handle_block_events(key, app),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ mod config;
 mod handlers;
 mod redirect_uri;
 mod ui;
-mod util;
 mod user_config;
+mod util;
 
 use clap::App as ClapApp;
 use rspotify::spotify::client::Spotify;
@@ -27,8 +27,8 @@ use tui::Terminal;
 use app::{ActiveBlock, App};
 use banner::BANNER;
 use config::{ClientConfig, LOCALHOST};
-use user_config::UserConfig;
 use redirect_uri::redirect_uri_web_server;
+use user_config::UserConfig;
 use util::{Event, Events};
 
 const SCOPES: [&str; 9] = [
@@ -207,19 +207,17 @@ fn main() -> Result<(), failure::Error> {
                         // case for the input handler
                         if current_active_block == ActiveBlock::Input {
                             handlers::input_handler(key, &mut app);
-                        } else {
-                            if key == app.user_config.back {
-                                if app.get_current_route().active_block != ActiveBlock::Input {
-                                    // Go back through navigation stack when not in search input mode and exit the app if there are no more places to back to
-                                    let pop_result = app.pop_navigation_stack();
+                        } else if key == app.user_config.back {
+                            if app.get_current_route().active_block != ActiveBlock::Input {
+                                // Go back through navigation stack when not in search input mode and exit the app if there are no more places to back to
+                                let pop_result = app.pop_navigation_stack();
 
-                                    if pop_result.is_none() {
-                                        break; // Exit application
-                                    }
+                                if pop_result.is_none() {
+                                    break; // Exit application
                                 }
-                            } else {
-                                handlers::handle_app(key, &mut app);
                             }
+                        } else {
+                            handlers::handle_app(key, &mut app);
                         }
                     }
                     Event::Tick => {

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -229,7 +229,7 @@ mod tests {
         use termion::event::Key;
 
         assert!(
-            check_reserved_keys(&Key::Char('\n')).is_err(),
+            check_reserved_keys(Key::Char('\n')).is_err(),
             "Enter key should be reserved"
         );
     }

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -9,79 +9,84 @@ const FILE_NAME: &str = "config.yml";
 const CONFIG_DIR: &str = ".config";
 const APP_CONFIG_DIR: &str = "spotify-tui";
 
-
 fn parse_key(key: String) -> Result<Key, failure::Error> {
+    fn get_single_char(string: &str) -> char {
+        match string.chars().nth(0) {
+            Some(c) => c,
+            None => panic!(),
+        }
+    }
 
-	fn get_single_char(string: &str) -> char {
-		match string.chars().nth(0) {
-			Some(c) => c,
-			None => panic!()
-		}
-	}
+    match key.len() {
+        1 => Ok(Key::Char(get_single_char(key.as_str()))),
+        _ => {
+            let sections: Vec<&str> = key.split('-').collect();
 
-	match key.len() {
-		1 => Ok(Key::Char(get_single_char(key.as_str()))),
-		_ => {
-			let sections: Vec<&str> = key.split("-").collect();
+            if sections.len() > 2 {
+                return Err(failure::format_err!(
+                    "Shortcut can only have 2 keys, \"{}\" has {}",
+                    key,
+                    sections.len()
+                ));
+            }
 
-			if sections.len() > 2 {
-				return Err(failure::format_err!("Shortcut can only have 2 keys, \"{}\" has {}", key, sections.len()));
-			}
-
-			match sections[0].to_lowercase().as_str() {
-				"ctrl" => Ok(Key::Ctrl(get_single_char(sections[1]))),
-				"alt" => Ok(Key::Alt(get_single_char(sections[1]))),
-				"left" => Ok(Key::Left),
-				"right" => Ok(Key::Right),
-				"up" => Ok(Key::Up),
-				"down" => Ok(Key::Down),
-				"backspace" | "delete" => Ok(Key::Backspace),
-				"del" => Ok(Key::Delete),
-				"esc" | "escape" => Ok(Key::Esc),
-				"pageup" => Ok(Key::PageUp),
-				"pagedown" => Ok(Key::PageDown),
-				"space" => Ok(Key::Char(' ')),
-				_ => Err(failure::format_err!("The key \"{}\" is unknown.", sections[0]))
-			}
-		}
-	}
+            match sections[0].to_lowercase().as_str() {
+                "ctrl" => Ok(Key::Ctrl(get_single_char(sections[1]))),
+                "alt" => Ok(Key::Alt(get_single_char(sections[1]))),
+                "left" => Ok(Key::Left),
+                "right" => Ok(Key::Right),
+                "up" => Ok(Key::Up),
+                "down" => Ok(Key::Down),
+                "backspace" | "delete" => Ok(Key::Backspace),
+                "del" => Ok(Key::Delete),
+                "esc" | "escape" => Ok(Key::Esc),
+                "pageup" => Ok(Key::PageUp),
+                "pagedown" => Ok(Key::PageDown),
+                "space" => Ok(Key::Char(' ')),
+                _ => Err(failure::format_err!(
+                    "The key \"{}\" is unknown.",
+                    sections[0]
+                )),
+            }
+        }
+    }
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UserConfigString {
-	back: Option<String>,
+    back: Option<String>,
     jump_to_album: Option<String>,
-	jump_to_artist_album: Option<String>,
-	manage_devices: Option<String>,
-	decrease_volume: Option<String>,
-	increase_volume: Option<String>,
-	toggle_playback: Option<String>,
-	seek_backwards: Option<String>,
-	seek_forwards: Option<String>,
-	next_track: Option<String>,
-	previous_track: Option<String>,
-	help: Option<String>,
-	shuffle: Option<String>,
-	repeat: Option<String>,
-	search: Option<String>
+    jump_to_artist_album: Option<String>,
+    manage_devices: Option<String>,
+    decrease_volume: Option<String>,
+    increase_volume: Option<String>,
+    toggle_playback: Option<String>,
+    seek_backwards: Option<String>,
+    seek_forwards: Option<String>,
+    next_track: Option<String>,
+    previous_track: Option<String>,
+    help: Option<String>,
+    shuffle: Option<String>,
+    repeat: Option<String>,
+    search: Option<String>,
 }
 
 pub struct UserConfig {
-	pub back: Key,
-	pub jump_to_album: Key,
-	pub jump_to_artist_album: Key,
-	pub manage_devices: Key,
-	pub decrease_volume: Key,
-	pub increase_volume: Key,
-	pub toggle_playback: Key,
-	pub seek_backwards: Key,
-	pub seek_forwards: Key,
-	pub next_track: Key,
-	pub previous_track: Key,
-	pub help: Key,
-	pub shuffle: Key,
-	pub repeat: Key,
-	pub search: Key
+    pub back: Key,
+    pub jump_to_album: Key,
+    pub jump_to_artist_album: Key,
+    pub manage_devices: Key,
+    pub decrease_volume: Key,
+    pub increase_volume: Key,
+    pub toggle_playback: Key,
+    pub seek_backwards: Key,
+    pub seek_forwards: Key,
+    pub next_track: Key,
+    pub previous_track: Key,
+    pub help: Key,
+    pub shuffle: Key,
+    pub repeat: Key,
+    pub search: Key,
 }
 
 pub struct UserConfigPaths {
@@ -91,21 +96,21 @@ pub struct UserConfigPaths {
 impl UserConfig {
     pub fn new() -> UserConfig {
         UserConfig {
-			back: Key::Char('q'),
-			jump_to_album: Key::Char('a'),
-			jump_to_artist_album: Key::Char('A'),
-			manage_devices: Key::Char('d'),
-			decrease_volume: Key::Char('-'),
-			increase_volume: Key::Char('+'),
-			toggle_playback: Key::Char(' '),
-			seek_backwards: Key::Char('<'),
-			seek_forwards: Key::Char('>'),
-			next_track: Key::Char('n'),
-			previous_track: Key::Char('p'),
-			help: Key::Char('?'),
-			shuffle: Key::Char('s'),
-			repeat: Key::Char('r'),
-			search: Key::Char('/')
+            back: Key::Char('q'),
+            jump_to_album: Key::Char('a'),
+            jump_to_artist_album: Key::Char('A'),
+            manage_devices: Key::Char('d'),
+            decrease_volume: Key::Char('-'),
+            increase_volume: Key::Char('+'),
+            toggle_playback: Key::Char(' '),
+            seek_backwards: Key::Char('<'),
+            seek_forwards: Key::Char('>'),
+            next_track: Key::Char('n'),
+            previous_track: Key::Char('p'),
+            help: Key::Char('?'),
+            shuffle: Key::Char('s'),
+            repeat: Key::Char('r'),
+            search: Key::Char('/'),
         }
     }
 
@@ -141,50 +146,50 @@ impl UserConfig {
         if paths.config_file_path.exists() {
             let config_string = fs::read_to_string(&paths.config_file_path)?;
             let config_yml: UserConfigString = serde_yaml::from_str(&config_string)?;
-			
-			macro_rules! to_keys {
-				($name: ident) => {
-					if let Some(key_string) = config_yml.$name {
-						self.$name = parse_key(key_string)?;
-					}
-				};
-			};
 
-			to_keys!(back);
-			to_keys!(jump_to_album);
-			to_keys!(jump_to_artist_album);
-			to_keys!(manage_devices);
-			to_keys!(decrease_volume);
-			to_keys!(increase_volume);
-			to_keys!(toggle_playback);
-			to_keys!(seek_backwards);
-			to_keys!(seek_forwards);
-			to_keys!(next_track);
-			to_keys!(previous_track);
-			to_keys!(help);
-			to_keys!(shuffle);
-			to_keys!(repeat);
-			to_keys!(search);
+            macro_rules! to_keys {
+                ($name: ident) => {
+                    if let Some(key_string) = config_yml.$name {
+                        self.$name = parse_key(key_string)?;
+                    }
+                };
+            };
+
+            to_keys!(back);
+            to_keys!(jump_to_album);
+            to_keys!(jump_to_artist_album);
+            to_keys!(manage_devices);
+            to_keys!(decrease_volume);
+            to_keys!(increase_volume);
+            to_keys!(toggle_playback);
+            to_keys!(seek_backwards);
+            to_keys!(seek_forwards);
+            to_keys!(next_track);
+            to_keys!(previous_track);
+            to_keys!(help);
+            to_keys!(shuffle);
+            to_keys!(repeat);
+            to_keys!(search);
 
             Ok(())
         } else {
-			Ok(())
-		}
+            Ok(())
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-	#[test]
-	fn test_parse_key() {
-		use super::parse_key;
-		use termion::event::Key;
-		assert_eq!(parse_key(String::from("j")).unwrap(), Key::Char('j'));
-		assert_eq!(parse_key(String::from("J")).unwrap(), Key::Char('J'));
-		assert_eq!(parse_key(String::from("ctrl-j")).unwrap(), Key::Ctrl('j'));
-		assert_eq!(parse_key(String::from("ctrl-J")).unwrap(), Key::Ctrl('J'));
-		assert_eq!(parse_key(String::from("-")).unwrap(), Key::Char('-'));
-		assert_eq!(parse_key(String::from("esc")).unwrap(), Key::Esc);
-		assert_eq!(parse_key(String::from("del")).unwrap(), Key::Delete);
-	}
+    #[test]
+    fn test_parse_key() {
+        use super::parse_key;
+        use termion::event::Key;
+        assert_eq!(parse_key(String::from("j")).unwrap(), Key::Char('j'));
+        assert_eq!(parse_key(String::from("J")).unwrap(), Key::Char('J'));
+        assert_eq!(parse_key(String::from("ctrl-j")).unwrap(), Key::Ctrl('j'));
+        assert_eq!(parse_key(String::from("ctrl-J")).unwrap(), Key::Ctrl('J'));
+        assert_eq!(parse_key(String::from("-")).unwrap(), Key::Char('-'));
+        assert_eq!(parse_key(String::from("esc")).unwrap(), Key::Esc);
+        assert_eq!(parse_key(String::from("del")).unwrap(), Key::Delete);
+    }
 }

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -1,0 +1,190 @@
+use dirs;
+use failure::err_msg;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use termion::event::Key;
+
+const FILE_NAME: &str = "config.yml";
+const CONFIG_DIR: &str = ".config";
+const APP_CONFIG_DIR: &str = "spotify-tui";
+
+
+fn parse_key(key: String) -> Result<Key, failure::Error> {
+
+	fn get_single_char(string: &str) -> char {
+		match string.chars().nth(0) {
+			Some(c) => c,
+			None => panic!()
+		}
+	}
+
+	match key.len() {
+		1 => Ok(Key::Char(get_single_char(key.as_str()))),
+		_ => {
+			let sections: Vec<&str> = key.split("-").collect();
+
+			if sections.len() > 2 {
+				return Err(failure::format_err!("Shortcut can only have 2 keys, \"{}\" has {}", key, sections.len()));
+			}
+
+			match sections[0].to_lowercase().as_str() {
+				"ctrl" => Ok(Key::Ctrl(get_single_char(sections[1]))),
+				"alt" => Ok(Key::Alt(get_single_char(sections[1]))),
+				"left" => Ok(Key::Left),
+				"right" => Ok(Key::Right),
+				"up" => Ok(Key::Up),
+				"down" => Ok(Key::Down),
+				"backspace" | "delete" => Ok(Key::Backspace),
+				"del" => Ok(Key::Delete),
+				"esc" | "escape" => Ok(Key::Esc),
+				"pageup" => Ok(Key::PageUp),
+				"pagedown" => Ok(Key::PageDown),
+				"space" => Ok(Key::Char(' ')),
+				_ => Err(failure::format_err!("The key \"{}\" is unknown.", sections[0]))
+			}
+		}
+	}
+}
+
+#[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct UserConfigString {
+	back: Option<String>,
+    jump_to_album: Option<String>,
+	jump_to_artist_album: Option<String>,
+	manage_devices: Option<String>,
+	decrease_volume: Option<String>,
+	increase_volume: Option<String>,
+	toggle_playback: Option<String>,
+	seek_backwards: Option<String>,
+	seek_forwards: Option<String>,
+	next_track: Option<String>,
+	previous_track: Option<String>,
+	help: Option<String>,
+	shuffle: Option<String>,
+	repeat: Option<String>,
+	search: Option<String>
+}
+
+pub struct UserConfig {
+	pub back: Key,
+	pub jump_to_album: Key,
+	pub jump_to_artist_album: Key,
+	pub manage_devices: Key,
+	pub decrease_volume: Key,
+	pub increase_volume: Key,
+	pub toggle_playback: Key,
+	pub seek_backwards: Key,
+	pub seek_forwards: Key,
+	pub next_track: Key,
+	pub previous_track: Key,
+	pub help: Key,
+	pub shuffle: Key,
+	pub repeat: Key,
+	pub search: Key
+}
+
+pub struct UserConfigPaths {
+    pub config_file_path: PathBuf,
+}
+
+impl UserConfig {
+    pub fn new() -> UserConfig {
+        UserConfig {
+			back: Key::Char('q'),
+			jump_to_album: Key::Char('a'),
+			jump_to_artist_album: Key::Char('A'),
+			manage_devices: Key::Char('d'),
+			decrease_volume: Key::Char('-'),
+			increase_volume: Key::Char('+'),
+			toggle_playback: Key::Char(' '),
+			seek_backwards: Key::Char('<'),
+			seek_forwards: Key::Char('>'),
+			next_track: Key::Char('n'),
+			previous_track: Key::Char('p'),
+			help: Key::Char('?'),
+			shuffle: Key::Char('s'),
+			repeat: Key::Char('r'),
+			search: Key::Char('/')
+        }
+    }
+
+    pub fn get_or_build_paths(&self) -> Result<(UserConfigPaths), failure::Error> {
+        match dirs::home_dir() {
+            Some(home) => {
+                let path = Path::new(&home);
+                let home_config_dir = path.join(CONFIG_DIR);
+                let app_config_dir = home_config_dir.join(APP_CONFIG_DIR);
+
+                if !home_config_dir.exists() {
+                    fs::create_dir(&home_config_dir)?;
+                }
+
+                if !app_config_dir.exists() {
+                    fs::create_dir(&app_config_dir)?;
+                }
+
+                let config_file_path = &app_config_dir.join(FILE_NAME);
+
+                let paths = UserConfigPaths {
+                    config_file_path: config_file_path.to_path_buf(),
+                };
+
+                Ok(paths)
+            }
+            None => Err(err_msg("No $HOME directory found for client config")),
+        }
+    }
+
+    pub fn load_config(&mut self) -> Result<(), failure::Error> {
+        let paths = self.get_or_build_paths()?;
+        if paths.config_file_path.exists() {
+            let config_string = fs::read_to_string(&paths.config_file_path)?;
+            let config_yml: UserConfigString = serde_yaml::from_str(&config_string)?;
+			
+			macro_rules! to_keys {
+				($name: ident) => {
+					if let Some(key_string) = config_yml.$name {
+						self.$name = parse_key(key_string)?;
+					}
+				};
+			};
+
+			to_keys!(back);
+			to_keys!(jump_to_album);
+			to_keys!(jump_to_artist_album);
+			to_keys!(manage_devices);
+			to_keys!(decrease_volume);
+			to_keys!(increase_volume);
+			to_keys!(toggle_playback);
+			to_keys!(seek_backwards);
+			to_keys!(seek_forwards);
+			to_keys!(next_track);
+			to_keys!(previous_track);
+			to_keys!(help);
+			to_keys!(shuffle);
+			to_keys!(repeat);
+			to_keys!(search);
+
+            Ok(())
+        } else {
+			Ok(())
+		}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+	#[test]
+	fn test_parse_key() {
+		use super::parse_key;
+		use termion::event::Key;
+		assert_eq!(parse_key(String::from("j")).unwrap(), Key::Char('j'));
+		assert_eq!(parse_key(String::from("J")).unwrap(), Key::Char('J'));
+		assert_eq!(parse_key(String::from("ctrl-j")).unwrap(), Key::Ctrl('j'));
+		assert_eq!(parse_key(String::from("ctrl-J")).unwrap(), Key::Ctrl('J'));
+		assert_eq!(parse_key(String::from("-")).unwrap(), Key::Char('-'));
+		assert_eq!(parse_key(String::from("esc")).unwrap(), Key::Esc);
+		assert_eq!(parse_key(String::from("del")).unwrap(), Key::Delete);
+	}
+}


### PR DESCRIPTION
This will add a `config.yml` file along side the `client.yml` file which
will allow the user to configure custom keybindings.  Currently this
commit only covers global keybindings and not per-screen keybindings but
this could be added in the future. This commit also doesn't currently
allow for overriding default navigation keys (hjkl etc.) but that could
also be added later.

Resolves: #46