### PR TITLE
Fix panic when seeking beyond track boundaries

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -418,7 +418,15 @@ impl App {
     }
 
     pub fn seek_forwards(&mut self) {
-        self.seek(self.song_progress_ms as u32 + 5000);
+        if let Some(current_playback_context) = &self.current_playback_context {
+            if let Some(track) = &current_playback_context.item {
+                if track.duration_ms - self.song_progress_ms as u32 > 5000 {
+                    self.seek(self.song_progress_ms as u32 + 5000);
+                } else {
+                    self.next_track();
+                }
+            }
+        }
     }
 
     pub fn seek_backwards(&mut self) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -422,7 +422,12 @@ impl App {
     }
 
     pub fn seek_backwards(&mut self) {
-        self.seek(self.song_progress_ms as u32 - 5000);
+        let new_progress = if self.song_progress_ms > 5000 {
+            self.song_progress_ms as u32 - 5000
+        } else {
+            0u32
+        };
+        self.seek(new_progress);
     }
 
     pub fn pause_playback(&mut self) {


### PR DESCRIPTION
Addresses https://github.com/Rigellute/spotify-tui/issues/123.

Not sure if there is an edge case to be concerned about:
If the user is at the end of a track and attempts to seek forward twice quickly (between ticks), it may be possible that `self.next_track` is called twice and playback unexpectedly skips forward two tracks instead of the one as expected.

Am open to suggestions for better alternatives.