### PR TITLE
Prevent Gauge error when track progress is negative

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -672,7 +672,10 @@ where
             )
             .render(f, chunks[0]);
 
-            let perc = (app.song_progress_ms as f64 / f64::from(track_item.duration_ms)) * 100_f64;
+            let min_perc = 0_f64;
+            let track_perc =
+                (app.song_progress_ms as f64 / f64::from(track_item.duration_ms)) * 100_f64;
+            let perc = min_perc.max(track_perc);
 
             Gauge::default()
                 .block(Block::default().title(""))


### PR DESCRIPTION
This should not happen now due to the fixes in PR #124. However this is
an extra precaution in case tracks can have negative progress due to
some other bug in the future.

Closes #125 issue