### PR TITLE
Add support for scrolling up/down when album list is active

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -868,7 +868,7 @@ impl App {
             match spotify.current_user_saved_albums(self.large_search_limit, offset) {
                 Ok(saved_albums) => {
                     // not to show a blank page
-                    if saved_albums.items.len() > 0 {
+                    if !saved_albums.items.is_empty() {
                         self.library.saved_albums.add_pages(saved_albums);
                     }
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -862,4 +862,43 @@ impl App {
             };
         };
     }
+
+    pub fn get_current_user_saved_albums(&mut self, offset: Option<u32>) {
+        if let Some(spotify) = &self.spotify {
+            match spotify.current_user_saved_albums(self.large_search_limit, offset) {
+                Ok(saved_albums) => {
+                    // not to show a blank page
+                    if saved_albums.items.len() > 0 {
+                        self.library.saved_albums.add_pages(saved_albums);
+                    }
+                }
+                Err(e) => {
+                    self.handle_error(e);
+                }
+            }
+        }
+    }
+
+    pub fn get_current_user_saved_albums_next(&mut self) {
+        match self
+            .library
+            .saved_albums
+            .get_results(Some(self.library.saved_albums.index + 1))
+            .cloned()
+        {
+            Some(_) => self.library.saved_albums.index += 1,
+            None => {
+                if let Some(saved_albums) = &self.library.saved_albums.get_results(None) {
+                    let offset = Some(saved_albums.offset + saved_albums.limit);
+                    self.get_current_user_saved_albums(offset);
+                }
+            }
+        }
+    }
+
+    pub fn get_current_user_saved_albums_previous(&mut self) {
+        if self.library.saved_albums.index > 0 {
+            self.library.saved_albums.index -= 1;
+        }
+    }
 }

--- a/src/handlers/album_list.rs
+++ b/src/handlers/album_list.rs
@@ -35,6 +35,8 @@ pub fn handler(key: Key, app: &mut App) {
                 };
             }
         }
+        Key::Ctrl('d') => app.get_current_user_saved_albums_next(),
+        Key::Ctrl('u') => app.get_current_user_saved_albums_previous(),
         _ => {}
     };
 }

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -63,17 +63,8 @@ pub fn handler(key: Key, app: &mut App) {
             }
             // Albums,
             3 => {
-                if let Some(spotify) = &app.spotify {
-                    match spotify.current_user_saved_albums(app.large_search_limit, 0) {
-                        Ok(result) => {
-                            app.library.saved_albums.add_pages(result);
-                            app.push_navigation_stack(RouteId::AlbumList, ActiveBlock::AlbumList);
-                        }
-                        Err(e) => {
-                            app.handle_error(e);
-                        }
-                    }
-                };
+                app.get_current_user_saved_albums(Some(0));
+                app.push_navigation_stack(RouteId::AlbumList, ActiveBlock::AlbumList);
             }
             //  Artists,
             4 => {


### PR DESCRIPTION
This PR is related to #11

`ctrl+d/u` should scroll through pages but this has been implemented in "Liked Songs" view only. In this PR, I tried to implement scrolling down/up in the "Albums" view.

need to confirm:
In `src/app.rs`, I added three methods (`get_current_user_saved_albums`, `get_current_user_saved_albums_next`, and `get_current_user_saved_albums_previous`) for `App`. These methods are imitation of `**saved_tracks**` methods. Although `push_navigation_stack` is called in `get_current_user_saved_tracks`, I did **NOT** call `push_navigation_stack` in `get_current_user_saved_albums`.  If `push_navigation_stack` is called after each page scrolling, same contents are pushed into the stack. Scrolling pages several time, q key (go back) seems foul-up. This behavior seems a bug for me so I did not call `push_navigation_stack` in `get_current_user_saved_albums`.