### PR TITLE
Fix gauge error

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -672,9 +672,10 @@ where
             )
             .render(f, chunks[0]);
 
+            // Ensure track progress percentage is between 0 and 100 inclusive
             let min_perc = 0_f64;
-            let track_perc =
-                (app.song_progress_ms as f64 / f64::from(track_item.duration_ms)) * 100_f64;
+            let track_progress = std::cmp::min(app.song_progress_ms, track_item.duration_ms.into());
+            let track_perc = (track_progress as f64 / f64::from(track_item.duration_ms)) * 100_f64;
             let perc = min_perc.max(track_perc);
 
             Gauge::default()

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -13,7 +13,7 @@ use tui::widgets::{Block, Borders, Gauge, Paragraph, Row, SelectableList, Table,
 use tui::Frame;
 use util::{
     create_artist_string, display_track_progress, get_color, get_percentage_width,
-    get_search_results_highlight_state, millis_to_minutes,
+    get_search_results_highlight_state, get_track_progress_percentage, millis_to_minutes,
 };
 
 pub enum TableId {
@@ -671,12 +671,7 @@ where
                 ),
             )
             .render(f, chunks[0]);
-
-            // Ensure track progress percentage is between 0 and 100 inclusive
-            let min_perc = 0_f64;
-            let track_progress = std::cmp::min(app.song_progress_ms, track_item.duration_ms.into());
-            let track_perc = (track_progress as f64 / f64::from(track_item.duration_ms)) * 100_f64;
-            let perc = min_perc.max(track_perc);
+            let perc = get_track_progress_percentage(app.song_progress_ms, track_item.duration_ms);
 
             Gauge::default()
                 .block(Block::default().title(""))
@@ -686,7 +681,7 @@ where
                         .bg(Color::Black)
                         .modifier(Modifier::ITALIC | Modifier::BOLD),
                 )
-                .percent(perc as u16)
+                .percent(perc)
                 .label(&display_track_progress(
                     app.song_progress_ms,
                     track_item.duration_ms,

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -61,6 +61,14 @@ pub fn get_percentage_width(width: u16, percentage: f32) -> u16 {
     (f32::from(width) * percentage) as u16
 }
 
+// Ensure track progress percentage is between 0 and 100 inclusive
+pub fn get_track_progress_percentage(song_progress_ms: u128, track_duration_ms: u32) -> u16 {
+    let min_perc = 0_f64;
+    let track_progress = std::cmp::min(song_progress_ms, track_duration_ms.into());
+    let track_perc = (track_progress as f64 / f64::from(track_duration_ms)) * 100_f64;
+    min_perc.max(track_perc) as u16
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -85,6 +93,22 @@ mod tests {
         assert_eq!(
             display_track_progress(60 * 1000, 2 * 60 * 1000),
             "1:00/2:00 (-1:00)"
+        );
+    }
+
+    #[test]
+    fn get_track_progress_percentage_test() {
+        let track_length = 60 * 1000;
+        assert_eq!(get_track_progress_percentage(0, track_length), 0);
+        assert_eq!(
+            get_track_progress_percentage((60 * 1000) / 2, track_length),
+            50
+        );
+
+        // If progress is somehow higher than total duration, 100 should be max
+        assert_eq!(
+            get_track_progress_percentage(60 * 1000 * 2, track_length),
+            100
         );
     }
 }


### PR DESCRIPTION
Occasionally the track percentage goes out of bounds (0 & 100). There's
probably a more elegant fix for this, but this seems fine for now.