### PR TITLE
Revert "Add support for page scrolling in Playlist"

### DIFF
--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -60,7 +60,6 @@ pub fn handler(key: Key, app: &mut App) {
             // Liked Songs,
             2 => {
                 app.get_current_user_saved_tracks(None);
-                app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
             }
             // Albums,
             3 => {

--- a/src/handlers/playlist.rs
+++ b/src/handlers/playlist.rs
@@ -1,4 +1,4 @@
-use super::super::app::{ActiveBlock, App, RouteId, TrackTableContext};
+use super::super::app::{App, TrackTableContext};
 use super::common_key_events;
 use termion::event::Key;
 
@@ -40,8 +40,7 @@ pub fn handler(key: Key, app: &mut App) {
                     playlists.items.get(selected_playlist_index.to_owned())
                 {
                     let playlist_id = selected_playlist.id.to_owned();
-                    app.get_playlist_tracks(playlist_id, Some(0));
-                    app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+                    app.get_playlist_tracks(playlist_id);
                 }
             };
         }

--- a/src/handlers/search_results.rs
+++ b/src/handlers/search_results.rs
@@ -1,4 +1,4 @@
-use super::super::app::{ActiveBlock, App, RouteId, SearchResultBlock, TrackTableContext};
+use super::super::app::{App, SearchResultBlock, TrackTableContext};
 use super::common_key_events;
 use termion::event::Key;
 
@@ -164,8 +164,7 @@ fn handle_enter_event_on_selected_block(app: &mut App) {
                     // Go to playlist tracks table
                     app.track_table.context = Some(TrackTableContext::PlaylistSearch);
                     let playlist_id = playlist.id.to_owned();
-                    app.get_playlist_tracks(playlist_id, Some(0));
-                    app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+                    app.get_playlist_tracks(playlist_id);
                 };
             }
         }

--- a/src/handlers/track_table.rs
+++ b/src/handlers/track_table.rs
@@ -105,9 +105,7 @@ pub fn handler(key: Key, app: &mut App) {
         Key::Ctrl('d') => {
             match &app.track_table.context {
                 Some(context) => match context {
-                    TrackTableContext::MyPlaylists => {
-                        app.get_playlist_tracks_next();
-                    }
+                    TrackTableContext::MyPlaylists => {}
                     TrackTableContext::SavedTracks => {
                         app.get_current_user_saved_tracks_next();
                     }
@@ -121,9 +119,7 @@ pub fn handler(key: Key, app: &mut App) {
         Key::Ctrl('u') => {
             match &app.track_table.context {
                 Some(context) => match context {
-                    TrackTableContext::MyPlaylists => {
-                        app.get_playlist_tracks_previous();
-                    }
+                    TrackTableContext::MyPlaylists => {}
                     TrackTableContext::SavedTracks => {
                         app.get_current_user_saved_tracks_previous();
                     }


### PR DESCRIPTION
Reverts Rigellute/spotify-tui#133

One issue I found was that pressing "enter" to play a track, would play a track from the wrong page (I think it's only playing tracks from the first page?)