### PR TITLE
Fix paging in the Playlist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use termion::screen::AlternateScreen;
 use tui::backend::{Backend, TermionBackend};
 use tui::Terminal;
 
-use app::{ActiveBlock, App};
+use app::{ActiveBlock, App, RouteId, ScrollableResultPages /* TrackTableContext */};
 use banner::BANNER;
 use config::{ClientConfig, LOCALHOST};
 use redirect_uri::redirect_uri_web_server;
@@ -241,11 +241,25 @@ fn main() -> Result<(), failure::Error> {
                             handlers::input_handler(key, &mut app);
                         } else if key == app.user_config.keys.back {
                             if app.get_current_route().active_block != ActiveBlock::Input {
-                                // Go back through navigation stack when not in search input mode and exit the app if there are no more places to back to
-                                let pop_result = app.pop_navigation_stack();
-
-                                if pop_result.is_none() {
-                                    break; // Exit application
+                                match app.pop_navigation_stack() {
+                                    Some(route) => match route.id {
+                                        RouteId::TrackTable => {
+                                            app.playlist_tracks = ScrollableResultPages::new();
+                                        }
+                                        /*
+                                        RouteId::TrackTable => match app.track_table.context {
+                                            Some(TrackTableContext::PlaylistSearch) => {
+                                                app.playlist_tracks = ScrollableResultPages::new();
+                                            }
+                                            _ => {}
+                                        },
+                                        */
+                                        _ => {}
+                                    },
+                                    // Go back through navigation stack when not in search input mode and exit the app if there are no more places to back to
+                                    None => {
+                                        break;
+                                    }
                                 }
                             }
                         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,20 +242,25 @@ fn main() -> Result<(), failure::Error> {
                         } else if key == app.user_config.keys.back {
                             if app.get_current_route().active_block != ActiveBlock::Input {
                                 match app.pop_navigation_stack() {
+                                    Some(route) => {
+                                        if let RouteId::TrackTable = route.id {
+                                            app.playlist_tracks = ScrollableResultPages::new();
+                                        }
+                                    }
+                                    /*
                                     Some(route) => match route.id {
                                         RouteId::TrackTable => {
                                             app.playlist_tracks = ScrollableResultPages::new();
                                         }
-                                        /*
                                         RouteId::TrackTable => match app.track_table.context {
                                             Some(TrackTableContext::PlaylistSearch) => {
                                                 app.playlist_tracks = ScrollableResultPages::new();
                                             }
                                             _ => {}
                                         },
-                                        */
                                         _ => {}
                                     },
+                                    */
                                     // Go back through navigation stack when not in search input mode and exit the app if there are no more places to back to
                                     None => {
                                         break;


### PR DESCRIPTION
Fix the problem that a wrong track is played after open some playlists. https://github.com/Rigellute/spotify-tui/pull/133#issuecomment-549640154

Reset `playlist_tracks` when go back from the track table of a playlist and it fix the problem.

Paging in the playlist does not have problems that you pointed out and I found. Scrolling down/up works well and a correct track is played when i press enter in the track table of a playlist.

I commented out some codes that does not go well (line 249-256 in `main.rs`). Although it goes not work but it seems better to me. I do not know why those codes does work. Please check it.