### PR TITLE
fix: Update current progress at new track load

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -563,6 +563,7 @@ impl App {
         match result {
             Ok(()) => {
                 self.get_current_playback();
+                self.song_progress_ms = 0;
                 self.playback_params = PlaybackParams {
                     context_uri,
                     uris,


### PR DESCRIPTION
There was a race condition between selecting a new track and the track
progress updating; this caused the app to sometimes panic when
selecting a track which has a total duration less than the current
progress as it tries to report a negative remaining time in the playbar
(but it tries this with unsigned values).

```bash
/git/spot.. master λ › cargo run
   Compiling spotify-tui v0.8.0 (/home/user/git/spotify-tui)
    Finished dev [unoptimized + debuginfo] target(s) in 6.75s
     Running `target/debug/spt`
thread '<unnamed>' panicked at 'attempt to subtract with overflow', src/ui/util.rs:52:39
stack backtrace:
...
   6: core::panicking::panic
             at src/libcore/panicking.rs:49
   7: spt::ui::util::display_track_progress
             at src/ui/util.rs:52
   8: spt::ui::draw_playbar
             at src/ui/mod.rs:685
   9: spt::ui::draw_main_layout
             at src/ui/mod.rs:161
  10: spt::main::{{closure}}
             at src/main.rs:192
...
```

This, I think, was ultimately the root cause of https://github.com/Rigellute/spotify-tui/issues/125 and the solution we've been looking for with https://github.com/Rigellute/spotify-tui/pull/132 and https://github.com/Rigellute/spotify-tui/pull/126.