### PR TITLE
Add Ctrl+g and G vim style keybindings to move cursor to first and last line

### DIFF
--- a/src/handlers/album_list.rs
+++ b/src/handlers/album_list.rs
@@ -35,6 +35,12 @@ pub fn handler(key: Key, app: &mut App) {
                 };
             }
         }
+        Key::Ctrl('g') => {
+            common_key_events::go_first_line(app);
+        }
+        Key::Char('G') => {
+            common_key_events::go_last_line(app);
+        }
         Key::Ctrl('d') => app.get_current_user_saved_albums_next(),
         Key::Ctrl('u') => app.get_current_user_saved_albums_previous(),
         _ => {}

--- a/src/handlers/album_tracks.rs
+++ b/src/handlers/album_tracks.rs
@@ -82,6 +82,12 @@ pub fn handler(key: Key, app: &mut App) {
                 };
             }
         },
+        Key::Ctrl('g') => {
+            common_key_events::go_first_line(app);
+        }
+        Key::Char('G') => {
+            common_key_events::go_last_line(app);
+        }
         Key::Char('\n') => match app.album_table_context {
             AlbumTableContext::Full => {
                 if let Some(albums) = &app.library.clone().saved_albums.get_results(None) {

--- a/src/handlers/artist_albums.rs
+++ b/src/handlers/artist_albums.rs
@@ -48,6 +48,12 @@ pub fn handler(key: Key, app: &mut App) {
                 };
             }
         }
+        Key::Ctrl('g') => {
+            common_key_events::go_first_line(app);
+        }
+        Key::Char('G') => {
+            common_key_events::go_last_line(app);
+        }
         _ => {}
     };
 }

--- a/src/handlers/artists.rs
+++ b/src/handlers/artists.rs
@@ -28,6 +28,12 @@ pub fn handler(key: Key, app: &mut App) {
             let artist = &artists[app.artists_list_index];
             app.get_artist_albums(&artist.id.to_owned(), &artist.name.to_owned());
         }
+        Key::Ctrl('g') => {
+            common_key_events::go_first_line(app);
+        }
+        Key::Char('G') => {
+            common_key_events::go_last_line(app);
+        }
         _ => {}
     }
 }

--- a/src/handlers/playlist.rs
+++ b/src/handlers/playlist.rs
@@ -44,6 +44,12 @@ pub fn handler(key: Key, app: &mut App) {
                 }
             };
         }
+        Key::Ctrl('g') => {
+            common_key_events::go_first_line(app);
+        }
+        Key::Char('G') => {
+            common_key_events::go_last_line(app);
+        }
         _ => {}
     }
 }

--- a/src/handlers/recently_played.rs
+++ b/src/handlers/recently_played.rs
@@ -45,6 +45,12 @@ pub fn handler(key: Key, app: &mut App) {
                 app.start_playback(None, Some(track_uris), Some(app.recently_played.index));
             };
         }
+        Key::Ctrl('g') => {
+            common_key_events::go_first_line(app);
+        }
+        Key::Char('G') => {
+            common_key_events::go_last_line(app);
+        }
         _ => {}
     };
 }

--- a/src/handlers/search_results.rs
+++ b/src/handlers/search_results.rs
@@ -277,6 +277,12 @@ pub fn handler(key: Key, app: &mut App) {
                 handle_enter_event_on_hovered_block(app)
             }
         }
+        Key::Ctrl('g') => {
+            common_key_events::go_first_line(app);
+        }
+        Key::Char('G') => {
+            common_key_events::go_last_line(app);
+        }
         // Add `s` to "see more" on each option
         _ => {}
     }

--- a/src/handlers/track_table.rs
+++ b/src/handlers/track_table.rs
@@ -101,6 +101,12 @@ pub fn handler(key: Key, app: &mut App) {
                 None => {}
             };
         }
+        Key::Ctrl('g') => {
+            common_key_events::go_first_line(app);
+        }
+        Key::Char('G') => {
+            common_key_events::go_last_line(app);
+        }
         // Scroll down
         Key::Ctrl('d') => {
             match &app.track_table.context {


### PR DESCRIPTION
I add new keybindings for cursor motion.

ctrl+g and G are Vim-like keybinding that move cursor to first and last line of the list. Real vim keybinding to move cursor to first line is gg but it seems that  keybindings that use two or more key are not supported in this app so I assign the fiunction to ctrl+g.

I think that i implemented them in all blocks (Artists, Albums, Playlists and so on) but if you notice my over looking, please tell me it.