### PR TITLE
Added config module 'visuals' and added window margin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ keybindings:
     shuffle: 's'
     repeat: 'r'
     search: '/'
+
+visuals:
+    margin: 1
 ```
 
 ## Limitations

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -148,7 +148,7 @@ where
             ]
             .as_ref(),
         )
-        .margin(2)
+        .margin(app.user_config.visuals.margin)
         .split(f.size());
 
     // Search input and help

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -158,9 +158,7 @@ impl UserConfig {
                 search: Key::Char('/'),
                 submit: Key::Char('\n'),
             },
-            visuals: Visuals {
-                margin: 1,
-            }
+            visuals: Visuals { margin: 1 },
         }
     }
 

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -121,12 +121,20 @@ pub struct KeyBindings {
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Visuals {
+    pub margin: u16,
+}
+
+#[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UserConfigString {
     keybindings: Option<KeyBindingsString>,
+    visuals: Option<Visuals>,
 }
 
 pub struct UserConfig {
     pub keys: KeyBindings,
+    pub visuals: Visuals,
 }
 
 impl UserConfig {
@@ -150,6 +158,9 @@ impl UserConfig {
                 search: Key::Char('/'),
                 submit: Key::Char('\n'),
             },
+            visuals: Visuals {
+                margin: 1,
+            }
         }
     }
 
@@ -226,6 +237,10 @@ impl UserConfig {
 
             if let Some(keybindings) = config_yml.keybindings.clone() {
                 self.load_keybindings(keybindings)?;
+            }
+
+            if let Some(visuals) = config_yml.visuals.clone() {
+                self.visuals = visuals;
             }
 
             Ok(())


### PR DESCRIPTION
This PR references https://github.com/Rigellute/spotify-tui/issues/138. I added the functionality to configure through window margin in the configuration file.

E.g. to remove the margin add to `~/spotify-tui/config.yaml`

```
visuals:
    margin: 0
```

If the margin is unset its default value is 1 which I think looks better than the previous default of 2 if you want to keep the margin. @Rigellute what default margin do you prefer?