### PR TITLE
Use space more efficiently on small terminals

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -138,6 +138,9 @@ pub fn draw_main_layout<B>(f: &mut Frame<B>, app: &App)
 where
     B: Backend,
 {
+    // Make better use of space on small terminals
+    let margin = if app.size.height > 45 { 1 } else { 0 };
+
     let parent_layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints(
@@ -148,7 +151,7 @@ where
             ]
             .as_ref(),
         )
-        .margin(2)
+        .margin(margin)
         .split(f.size());
 
     // Search input and help


### PR DESCRIPTION
This commit closes #138

<img width="1017" alt="Screenshot 2019-11-06 at 09 30 24" src="https://user-images.githubusercontent.com/12150276/68326139-c5c68a80-00c2-11ea-9b06-7f73dd576a1b.png">

There will still be some padding on larger terminals but I've removed the padding when the height is small.

Also slightly reduced the amount of margin on larger terminals.