### PR TITLE
Go back does not work in Liked Songs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -686,7 +686,6 @@ impl App {
 
                     self.library.saved_tracks.add_pages(saved_tracks);
                     self.track_table.context = Some(TrackTableContext::SavedTracks);
-                    self.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
                 }
                 Err(e) => {
                     self.handle_error(e);

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -60,6 +60,7 @@ pub fn handler(key: Key, app: &mut App) {
             // Liked Songs,
             2 => {
                 app.get_current_user_saved_tracks(None);
+                app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
             }
             // Albums,
             3 => {


### PR DESCRIPTION
Go back `q` does not work as expected after scrolling pages in Liked Songs.
When i scrolled pages in Liked Songs and pushed `q`, i expected that the Library block is activated but nothing occurred.

This problem caused by calling push_navigation_stack in get_current_user_saved_tracks.
I tried to fix this problem by removing push_navigation_stack from get_current_user_saved_tracks and pushing to the stack is called first time.