### PR TITLE
Delete saved album

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -902,4 +902,18 @@ impl App {
             self.library.saved_albums.index -= 1;
         }
     }
+
+    pub fn delete_current_user_saved_album(&mut self) {
+        if let Some(albums) = self.library.saved_albums.get_results(None) {
+            if let Some(selected_album) = albums.items.get(self.album_list_index) {
+                if let Some(spotify) = &mut self.spotify {
+                    let album_id = &selected_album.album.id;
+                    match spotify.current_user_saved_albums_delete(&[album_id.to_owned()]) {
+                        Ok(_) => self.get_current_user_saved_albums(None),
+                        Err(e) => self.handle_error(e),
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/handlers/album_list.rs
+++ b/src/handlers/album_list.rs
@@ -37,6 +37,7 @@ pub fn handler(key: Key, app: &mut App) {
         }
         Key::Ctrl('d') => app.get_current_user_saved_albums_next(),
         Key::Ctrl('u') => app.get_current_user_saved_albums_previous(),
+        Key::Char('D') => app.delete_current_user_saved_album(),
         _ => {}
     };
 }


### PR DESCRIPTION
In the roadmap, delete saved contents is essential but it is not implemented yet.
Here, I tried to implement delete saved album and it seems to work well.

I assigned `D` to delete an album in album list but i do not know this key mapping is good for you and if you do not like this, please change key mapping.