### PR TITLE
Adjust search limits

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use rspotify::spotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth, TokenInf
 use rspotify::spotify::util::get_token;
 use rspotify::spotify::util::process_token;
 use rspotify::spotify::util::request_token;
-use std::cmp::min;
+use std::cmp::{max, min};
 use std::io::{self, Write};
 use std::panic::{self, PanicInfo};
 use std::time::{Duration, Instant};
@@ -173,8 +173,10 @@ fn main() -> Result<(), failure::Error> {
                     app.size = size;
 
                     // Based on the size of the terminal, adjust the search limit.
-                    let max_limit = 50;
-                    app.large_search_limit = min((f32::from(size.height) / 1.5) as u32, max_limit);
+                    let max_limit = max((app.size.height as u32) - 13, 50);
+                    app.large_search_limit = min((f32::from(size.height) / 1.4) as u32, max_limit);
+                    app.small_search_limit =
+                        min((f32::from(size.height) / 2.85) as u32, max_limit / 2);
                 };
 
                 let current_route = app.get_current_route();


### PR DESCRIPTION
When terminal size is changed, some contents are not showed in the table. Additionally, regardless terminal size, search returns only 4 contents.

Here, I tried to fix these problem, i adjust search limits depending on the terminal size. However, parameters I used here are not led deductively but empirically.

If you know the way to get height of each block, preferable implementation can be available. For me, my implementation is not smart and if you have any idea, please tell me it.