### PR TITLE
Fix columns width in Saved Albums

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -943,7 +943,7 @@ where
             },
             TableHeaderItem {
                 text: "Release Date",
-                width: get_percentage_width(layout_chunk.width, 1.0 / 3.0),
+                width: get_percentage_width(layout_chunk.width, 1.0 / 5.0),
                 ..Default::default()
             },
         ],


### PR DESCRIPTION
### Description of the issue
Massive PR! 😄 

The `Release Date` column was missing in the `Albums` table, which was caused by width exceeding the total available space.

The same happens for `Length` in `Recently Played Tracks` table, because of `Liked` column of fixed width `2`. I couldn't decide whether change it to a percentage calculated value or just subtract it from the next column (eg. `width: get_percentage_width(layout_chunk.width, 2.0 / 5.0) - 2`). What do you think @Rigellute ? 

| Before               | After               |
| -------------------- | ------------------- |
| <img width="600" alt="Screenshot 2019-11-24 at 21 16 03" src="https://user-images.githubusercontent.com/6296883/69502004-61009200-0f02-11ea-86da-33d964db7d6d.png"> | <img width="600" alt="Screenshot 2019-11-24 at 21 15 32" src="https://user-images.githubusercontent.com/6296883/69502001-5645fd00-0f02-11ea-9f3b-cfab929211b7.png"> |