### PR TITLE
Fix columns width in Recently Played Tracks

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -999,7 +999,8 @@ where
             TableHeaderItem {
                 id: ColumnId::SongTitle,
                 text: "Title",
-                width: get_percentage_width(layout_chunk.width, 2.0 / 5.0),
+                // We need to subtract the fixed value of the previous column
+                width: get_percentage_width(layout_chunk.width, 2.0 / 5.0) - 2,
             },
             TableHeaderItem {
                 text: "Artist",


### PR DESCRIPTION
### Description of the issue
The `Length` column was missing in the `Recently Played Tracks` table, which was caused by width exceeding the total available space.


| Before               | After               |
| -------------------- | ------------------- |
| <img width="500" alt="Screenshot 2019-11-25 at 09 55 21" src="https://user-images.githubusercontent.com/6296883/69530634-43671300-0f6a-11ea-972a-d77826e51b16.png"> | <img width="500" alt="Screenshot 2019-11-25 at 09 54 49" src="https://user-images.githubusercontent.com/6296883/69530579-29c5cb80-0f6a-11ea-85e6-774b5ea6d9be.png"> |