### PR TITLE
Small typo fix for AlbumTrack header

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -550,7 +550,7 @@ where
                 ..Default::default()
             },
             TableHeaderItem {
-                text: "AlbumTracks",
+                text: "Album",
                 width: get_percentage_width(layout_chunk.width, 0.3),
                 ..Default::default()
             },


### PR DESCRIPTION
Previously, the text of AlbumTrack was set to "AlbumText", when it should be simply "Album".