### PR TITLE
Adjust volume controls behaviour

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -467,7 +467,6 @@ impl App {
             match spotify.volume(volume_percent, Some(device_id.to_string())) {
                 Ok(()) => {
                     context.device.volume_percent = volume_percent.into();
-                    self.get_current_playback();
                 }
                 Err(e) => {
                     self.handle_error(e);


### PR DESCRIPTION
### Description of the issue
The volume control does not work as intended, if `+` and `-` are pressed in a moderate pace the value updates every second press, and after some time it starts to get even more messy.

### Solution to the issue
I have removed `get_current_playback` call after the successful volume change. In this context I think it is not necessary to poll for the playback data, but maybe I am missing something, would you be able to confirm it @Rigellute ?

### Before/After screenshots 📷

| Before               | After               |
| -------------------- | ------------------- |
| ![bbb](https://user-images.githubusercontent.com/6296883/69582912-89a38d00-0fd1-11ea-9347-ddbe4863396e.gif) | ![aaa](https://user-images.githubusercontent.com/6296883/69582881-755f9000-0fd1-11ea-8288-282b3e261bbf.gif) |