### PR TITLE
Playlist: add shortcuts to jump to the start or the end

### DIFF
--- a/src/handlers/track_table.rs
+++ b/src/handlers/track_table.rs
@@ -155,6 +155,66 @@ pub fn handler(key: Key, app: &mut App) {
                 None => {}
             };
         }
+        Key::Ctrl('e') => jump_to_end(app),
+        Key::Ctrl('a') => jump_to_start(app),
         _ => {}
-    };
+    }
+}
+
+fn jump_to_end(app: &mut App) {
+    match &app.track_table.context {
+        Some(context) => match context {
+            TrackTableContext::MyPlaylists => {
+                if let (Some(playlists), Some(selected_playlist_index)) =
+                    (&app.playlists, &app.selected_playlist_index)
+                {
+                    if let Some(selected_playlist) =
+                        playlists.items.get(selected_playlist_index.to_owned())
+                    {
+                        let total_tracks = selected_playlist
+                            .tracks
+                            .get("total")
+                            .and_then(|total| total.as_u64())
+                            .expect("playlist.tracks object should have a total field")
+                            as u32;
+
+                        if app.large_search_limit < total_tracks {
+                            app.playlist_offset =
+                                total_tracks - (total_tracks % app.large_search_limit);
+                            let playlist_id = selected_playlist.id.to_owned();
+                            app.get_playlist_tracks(playlist_id);
+                        }
+                    }
+                }
+            }
+            TrackTableContext::SavedTracks => {}
+            TrackTableContext::AlbumSearch => {}
+            TrackTableContext::PlaylistSearch => {}
+        },
+        None => {}
+    }
+}
+
+fn jump_to_start(app: &mut App) {
+    match &app.track_table.context {
+        Some(context) => match context {
+            TrackTableContext::MyPlaylists => {
+                if let (Some(playlists), Some(selected_playlist_index)) =
+                    (&app.playlists, &app.selected_playlist_index)
+                {
+                    if let Some(selected_playlist) =
+                        playlists.items.get(selected_playlist_index.to_owned())
+                    {
+                        app.playlist_offset = 0;
+                        let playlist_id = selected_playlist.id.to_owned();
+                        app.get_playlist_tracks(playlist_id);
+                    }
+                }
+            }
+            TrackTableContext::SavedTracks => {}
+            TrackTableContext::AlbumSearch => {}
+            TrackTableContext::PlaylistSearch => {}
+        },
+        None => {}
+    }
 }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -76,6 +76,8 @@ pub fn get_help_docs() -> Vec<Vec<&'static str>> {
             "<Ctrl+u>",
             "Pagination",
         ],
+        vec!["Jump to start of playlist", "<Ctrl+a>", "Pagination"],
+        vec!["Jump to end of playlist", "<Ctrl+e>", "Pagination"],
         vec!["Delete saved album", "D", "Library -> Albums"],
         vec!["Follow an artists", "w", "Search result"],
     ]


### PR DESCRIPTION
Hello,

Here's a patch to allow a user to jump to the end / start of a playlist.

I used the same shortcut as the one used to go at the end / start of the search input but I'm not sure if you are ok with that. If you are, I guess we'd have to find how to specify it in the help page.

I also didn't implement it for other variants of `TrackTableContext` as I'm not sure if that's worth it.

Let me know how you feel about this and thanks for your work on this client :)