### PR TITLE
make seeking amount configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ keybindings:
   shuffle: "s"
   repeat: "r"
   search: "/"
+
+seek_seconds: 5
 ```
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ The following is a sample config.yml file:
 ```yaml
 # Sample config file
 
+behavior:
+  seek_milliseconds: 5000
+
 keybindings:
   # Key stroke can be used if it only uses two keys:
   # ctrl-q works,
@@ -158,8 +161,6 @@ keybindings:
   shuffle: "s"
   repeat: "r"
   search: "/"
-
-seek_seconds: 5
 ```
 
 ## Limitations

--- a/src/app.rs
+++ b/src/app.rs
@@ -428,9 +428,11 @@ impl App {
         if let Some(current_playback_context) = &self.current_playback_context {
             if let Some(track) = &current_playback_context.item {
                 if track.duration_ms - self.song_progress_ms as u32
-                    > self.user_config.seek_milliseconds
+                    > self.user_config.behavior.seek_milliseconds
                 {
-                    self.seek(self.song_progress_ms as u32 + self.user_config.seek_milliseconds);
+                    self.seek(
+                        self.song_progress_ms as u32 + self.user_config.behavior.seek_milliseconds,
+                    );
                 } else {
                     self.next_track();
                 }
@@ -439,11 +441,12 @@ impl App {
     }
 
     pub fn seek_backwards(&mut self) {
-        let new_progress = if self.song_progress_ms as u32 > self.user_config.seek_milliseconds {
-            self.song_progress_ms as u32 - self.user_config.seek_milliseconds
-        } else {
-            0u32
-        };
+        let new_progress =
+            if self.song_progress_ms as u32 > self.user_config.behavior.seek_milliseconds {
+                self.song_progress_ms as u32 - self.user_config.behavior.seek_milliseconds
+            } else {
+                0u32
+            };
         self.seek(new_progress);
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -427,8 +427,10 @@ impl App {
     pub fn seek_forwards(&mut self) {
         if let Some(current_playback_context) = &self.current_playback_context {
             if let Some(track) = &current_playback_context.item {
-                if track.duration_ms - self.song_progress_ms as u32 > 5000 {
-                    self.seek(self.song_progress_ms as u32 + 5000);
+                if track.duration_ms - self.song_progress_ms as u32
+                    > self.user_config.seek_milliseconds
+                {
+                    self.seek(self.song_progress_ms as u32 + self.user_config.seek_milliseconds);
                 } else {
                     self.next_track();
                 }
@@ -437,8 +439,8 @@ impl App {
     }
 
     pub fn seek_backwards(&mut self) {
-        let new_progress = if self.song_progress_ms > 5000 {
-            self.song_progress_ms as u32 - 5000
+        let new_progress = if self.song_progress_ms as u32 > self.user_config.seek_milliseconds {
+            self.song_progress_ms as u32 - self.user_config.seek_milliseconds
         } else {
             0u32
         };

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -125,10 +125,12 @@ pub struct KeyBindings {
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UserConfigString {
     keybindings: Option<KeyBindingsString>,
+    seek_seconds: Option<u32>,
 }
 
 pub struct UserConfig {
     pub keys: KeyBindings,
+    pub seek_milliseconds: u32,
 }
 
 impl UserConfig {
@@ -153,6 +155,7 @@ impl UserConfig {
                 submit: Key::Char('\n'),
                 copy_song_url: Key::Char('c'),
             },
+            seek_milliseconds: 5 * 1000,
         }
     }
 
@@ -230,6 +233,10 @@ impl UserConfig {
 
             if let Some(keybindings) = config_yml.keybindings.clone() {
                 self.load_keybindings(keybindings)?;
+            }
+
+            if let Some(seek_seconds) = config_yml.seek_seconds {
+                self.seek_milliseconds = seek_seconds * 1000;
             }
 
             Ok(())


### PR DESCRIPTION
This adds the config value `seek_seconds` to change much `spotify-tui` seeks when pressing the seek hotkeys. 
Default is still `5000` ms. 