### PR TITLE
Adjust min/max volume values

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -17,6 +17,7 @@ use rspotify::spotify::model::search::{
 use rspotify::spotify::model::track::{FullTrack, SavedTrack, SimplifiedTrack};
 use rspotify::spotify::model::user::PrivateUser;
 use rspotify::spotify::senum::{Country, RepeatState};
+use std::cmp::{max, min};
 use std::collections::HashSet;
 use std::time::Instant;
 use tui::layout::Rect;
@@ -477,8 +478,10 @@ impl App {
 
     pub fn increase_volume(&mut self) {
         if let Some(context) = self.current_playback_context.clone() {
-            let next_volume = context.device.volume_percent as u8 + 10;
-            if next_volume <= 100 {
+            let current_volume = context.device.volume_percent as u8;
+            let next_volume = min(current_volume + 10, 100);
+
+            if next_volume != current_volume {
                 self.change_volume(next_volume);
             }
         }
@@ -486,10 +489,11 @@ impl App {
 
     pub fn decrease_volume(&mut self) {
         if let Some(context) = self.current_playback_context.clone() {
-            let volume = context.device.volume_percent;
-            if volume >= 10 {
-                let next_volume = context.device.volume_percent as u8 - 10;
-                self.change_volume(next_volume);
+            let current_volume = context.device.volume_percent as i8;
+            let next_volume = max(current_volume - 10, 0);
+
+            if next_volume != current_volume {
+                self.change_volume(next_volume as u8);
             }
         }
     }


### PR DESCRIPTION
### Description of the issue
Currently if the initial volume is not of full tens (eg. `42`) then the min and max values are respectively `2` and `92`.

### Solution to the issue
Limit the volume values correctly on `0` and `100`.

### Before/After screenshots 📷

| Before               | After               |
| -------------------- | ------------------- |
| ![v2](https://user-images.githubusercontent.com/6296883/69675197-0009c300-1096-11ea-953c-f6114aa1b196.gif) | ![v1](https://user-images.githubusercontent.com/6296883/69675211-0c8e1b80-1096-11ea-84d4-9c09c9a46f8d.gif) |