### PR TITLE
Fix playlist index after search

### DIFF
--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -102,7 +102,7 @@ pub fn handler(key: Key, app: &mut App) {
                 }
 
                 // On searching for a track, clear the playlist selection
-                app.selected_playlist_index = None;
+                app.selected_playlist_index = Some(0);
                 app.push_navigation_stack(RouteId::Search, ActiveBlock::SearchResultBlock);
             }
         }


### PR DESCRIPTION
After searching, playlist index is changed to `None` and it makes playlist selection odd.
I deleted a line that binds `None` to `selected_playlist_index` and it worked well.