### PR TITLE
175: Fix cursor offset in search input

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -216,11 +216,17 @@ fn main() -> Result<(), failure::Error> {
                     };
                 }
 
+                let cursor_offset = if app.size.height > ui::SMALL_TERMINAL_HEIGHT {
+                    3
+                } else {
+                    2
+                };
+
                 // Put the cursor back inside the input box
                 write!(
                     terminal.backend_mut(),
                     "{}",
-                    Goto(3 + app.input_cursor_position, 3)
+                    Goto(cursor_offset + app.input_cursor_position, cursor_offset)
                 )?;
 
                 // stdout is buffered, flush it to see the effect immediately when hitting backspace

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,6 +16,8 @@ use util::{
     get_search_results_highlight_state, get_track_progress_percentage, millis_to_minutes,
 };
 
+pub const SMALL_TERMINAL_HEIGHT: u16 = 45;
+
 pub enum TableId {
     Album,
     AlbumList,
@@ -139,7 +141,11 @@ where
     B: Backend,
 {
     // Make better use of space on small terminals
-    let margin = if app.size.height > 45 { 1 } else { 0 };
+    let margin = if app.size.height > SMALL_TERMINAL_HEIGHT {
+        1
+    } else {
+        0
+    };
 
     let parent_layout = Layout::default()
         .direction(Direction::Vertical)


### PR DESCRIPTION
On smaller height terminals, the cursor position was off.

Fix is to apply the same offset differences on small/large terminals as is applied to the margin.

This commit closes https://github.com/Rigellute/spotify-tui/issues/175