### PR TITLE
Remove focus on input when jumping back

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use termion::screen::AlternateScreen;
 use tui::backend::{Backend, TermionBackend};
 use tui::Terminal;
 
-use app::{ActiveBlock, App};
+use app::{ActiveBlock, App, RouteId};
 use banner::BANNER;
 use config::{ClientConfig, LOCALHOST};
 use redirect_uri::redirect_uri_web_server;
@@ -259,8 +259,14 @@ fn main() -> Result<(), failure::Error> {
                         } else if key == app.user_config.keys.back {
                             if app.get_current_route().active_block != ActiveBlock::Input {
                                 // Go back through navigation stack when not in search input mode and exit the app if there are no more places to back to
-                                let pop_result = app.pop_navigation_stack();
 
+                                let pop_result = match app.pop_navigation_stack() {
+                                    Some(ref x) if x.id == RouteId::Search => {
+                                        app.pop_navigation_stack()
+                                    }
+                                    Some(x) => Some(x),
+                                    None => None,
+                                };
                                 if pop_result.is_none() {
                                     break; // Exit application
                                 }


### PR DESCRIPTION
This is fixing #174 

First of all I wanted to say that I'm pretty new to Rust so if you notice anything and have tips for me please feel free to share them with me :)

Also I realized that if the first action is to use the input field (thus the second route in the `navigation_stack` being a route with the id `Search`) the `Home` route will not be shown on navigating back because the second route will be popped in the match I've added and the `is_none()` check will break after...

I didn't know how to prevent this effectively without slaughtering the code. So any ideas would be really appreciated.