### PR TITLE
Pad strings in status bar to prevent reformatting

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -638,7 +638,7 @@ where
             };
 
             let title = format!(
-                "{} ({} | Shuffle: {} | Repeat: {} | Volume: {}%)",
+                "{:-7} ({} | Shuffle: {:-3} | Repeat: {:-5} | Volume: {:-2}%)",
                 play_title,
                 current_playback_context.device.name,
                 shuffle_text,


### PR DESCRIPTION


Currently there are different-length strings for parameters, such as
`On` and `Off`. When you switch options, the bottom status bar
reformats. This is a worse user experience, so this diff pads the bottom
status line so that it never reformats.

The included gifs show the end result.

### Old
![old_spt](https://user-images.githubusercontent.com/15932179/70408485-29631100-19fd-11ea-8733-84cae330f76f.gif)

### New
![improved_spt](https://user-images.githubusercontent.com/15932179/70408501-3f70d180-19fd-11ea-9fc2-b4fe6ceff00a.gif)
