### PR TITLE
Add support for Related artists and top tacks

### DIFF
--- a/src/handlers/artist.rs
+++ b/src/handlers/artist.rs
@@ -1,0 +1,207 @@
+use super::common_key_events;
+use crate::app::{App, ArtistBlock, TrackTableContext};
+use crate::event::Key;
+
+fn handle_down_press_on_selected_block(app: &mut App) {
+    if let Some(artist) = &mut app.artist {
+        match artist.artist_selected_block {
+            ArtistBlock::TopTracks => {
+                let next_index = common_key_events::on_down_press_handler(
+                    &artist.top_tracks,
+                    Some(artist.selected_top_track_index),
+                );
+                artist.selected_top_track_index = next_index;
+            }
+            ArtistBlock::Albums => {
+                let next_index = common_key_events::on_down_press_handler(
+                    &artist.albums.items,
+                    Some(artist.selected_album_index),
+                );
+                artist.selected_album_index = next_index;
+            }
+            ArtistBlock::RelatedArtists => {
+                let next_index = common_key_events::on_down_press_handler(
+                    &artist.related_artists,
+                    Some(artist.selected_related_artist_index),
+                );
+                artist.selected_related_artist_index = next_index;
+            }
+            ArtistBlock::Empty => {}
+        }
+    }
+}
+
+fn handle_down_press_on_hovered_block(app: &mut App) {
+    if let Some(artist) = &mut app.artist {
+        match artist.artist_hovered_block {
+            ArtistBlock::TopTracks => {
+                artist.artist_hovered_block = ArtistBlock::Albums;
+            }
+            ArtistBlock::Albums => {
+                artist.artist_hovered_block = ArtistBlock::RelatedArtists;
+            }
+            ArtistBlock::RelatedArtists => {
+                artist.artist_hovered_block = ArtistBlock::TopTracks;
+            }
+            ArtistBlock::Empty => {}
+        }
+    }
+}
+
+fn handle_up_press_on_selected_block(app: &mut App) {
+    if let Some(artist) = &mut app.artist {
+        match artist.artist_selected_block {
+            ArtistBlock::TopTracks => {
+                let next_index = common_key_events::on_up_press_handler(
+                    &artist.top_tracks,
+                    Some(artist.selected_top_track_index),
+                );
+                artist.selected_top_track_index = next_index;
+            }
+            ArtistBlock::Albums => {
+                let next_index = common_key_events::on_up_press_handler(
+                    &artist.albums.items,
+                    Some(artist.selected_album_index),
+                );
+                artist.selected_album_index = next_index;
+            }
+            ArtistBlock::RelatedArtists => {
+                let next_index = common_key_events::on_up_press_handler(
+                    &artist.related_artists,
+                    Some(artist.selected_related_artist_index),
+                );
+                artist.selected_related_artist_index = next_index;
+            }
+            ArtistBlock::Empty => {}
+        }
+    }
+}
+
+fn handle_up_press_on_hovered_block(app: &mut App) {
+    if let Some(artist) = &mut app.artist {
+        match artist.artist_hovered_block {
+            ArtistBlock::TopTracks => {
+                artist.artist_hovered_block = ArtistBlock::RelatedArtists;
+            }
+            ArtistBlock::Albums => {
+                artist.artist_hovered_block = ArtistBlock::TopTracks;
+            }
+            ArtistBlock::RelatedArtists => {
+                artist.artist_hovered_block = ArtistBlock::Albums;
+            }
+            ArtistBlock::Empty => {}
+        }
+    }
+}
+
+fn handle_enter_event_on_selected_block(app: &mut App) {
+    if let Some(artist) = &mut app.artist.clone() {
+        match artist.artist_selected_block {
+            ArtistBlock::TopTracks => {
+                let selected_index = artist.selected_top_track_index;
+                let top_tracks = artist
+                    .top_tracks
+                    .iter()
+                    .map(|track| track.uri.to_owned())
+                    .collect();
+                app.start_playback(None, Some(top_tracks), Some(selected_index));
+            }
+            ArtistBlock::Albums => {
+                if let Some(selected_album) = artist
+                    .albums
+                    .items
+                    .get(artist.selected_album_index)
+                    .cloned()
+                {
+                    app.track_table.context = Some(TrackTableContext::AlbumSearch);
+                    app.get_album_tracks(selected_album);
+                }
+            }
+            ArtistBlock::RelatedArtists => {
+                let selected_index = artist.selected_related_artist_index;
+                let artist_id = &artist.related_artists[selected_index].id;
+                let artist_name = &artist.related_artists[selected_index].name;
+                app.get_artist(&artist_id, &artist_name);
+            }
+            ArtistBlock::Empty => {}
+        }
+    }
+}
+
+fn handle_enter_event_on_hovered_block(app: &mut App) {
+    if let Some(artist) = &mut app.artist {
+        match artist.artist_hovered_block {
+            ArtistBlock::TopTracks => artist.artist_selected_block = ArtistBlock::TopTracks,
+            ArtistBlock::Albums => artist.artist_selected_block = ArtistBlock::Albums,
+            ArtistBlock::RelatedArtists => {
+                artist.artist_selected_block = ArtistBlock::RelatedArtists
+            }
+            ArtistBlock::Empty => {}
+        }
+    }
+}
+
+pub fn handler(key: Key, app: &mut App) {
+    if let Some(artist) = &mut app.artist {
+        match key {
+            Key::Esc => {
+                artist.artist_selected_block = ArtistBlock::Empty;
+            }
+            k if common_key_events::down_event(k) => {
+                if artist.artist_selected_block != ArtistBlock::Empty {
+                    handle_down_press_on_selected_block(app);
+                } else {
+                    handle_down_press_on_hovered_block(app);
+                }
+            }
+            k if common_key_events::up_event(k) => {
+                if artist.artist_selected_block != ArtistBlock::Empty {
+                    handle_up_press_on_selected_block(app);
+                } else {
+                    handle_up_press_on_hovered_block(app);
+                }
+            }
+            k if common_key_events::left_event(k) => {
+                artist.artist_selected_block = ArtistBlock::Empty;
+                match artist.artist_hovered_block {
+                    ArtistBlock::TopTracks => common_key_events::handle_left_event(app),
+                    ArtistBlock::Albums => {
+                        artist.artist_hovered_block = ArtistBlock::TopTracks;
+                    }
+                    ArtistBlock::RelatedArtists => {
+                        artist.artist_hovered_block = ArtistBlock::Albums;
+                    }
+                    ArtistBlock::Empty => {}
+                }
+            }
+            k if common_key_events::right_event(k) => {
+                artist.artist_selected_block = ArtistBlock::Empty;
+                handle_down_press_on_hovered_block(app);
+            }
+            Key::Enter => {
+                if artist.artist_selected_block != ArtistBlock::Empty {
+                    handle_enter_event_on_selected_block(app);
+                } else {
+                    handle_enter_event_on_hovered_block(app);
+                }
+            }
+            _ => {}
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::ActiveBlock;
+
+    #[test]
+    fn on_esc() {
+        let mut app = App::new();
+
+        handler(Key::Esc, &mut app);
+
+        let current_route = app.get_current_route();
+        assert_eq!(current_route.active_block, ActiveBlock::Empty);
+    }
+}

--- a/src/handlers/artists.rs
+++ b/src/handlers/artists.rs
@@ -1,5 +1,8 @@
 use super::common_key_events;
-use crate::{app::App, event::Key};
+use crate::{
+    app::{ActiveBlock, App, RouteId},
+    event::Key,
+};
 
 pub fn handler(key: Key, app: &mut App) {
     match key {
@@ -25,7 +28,8 @@ pub fn handler(key: Key, app: &mut App) {
         Key::Enter => {
             let artists = app.artists.to_owned();
             let artist = &artists[app.artists_list_index];
-            app.get_artist_albums(&artist.id.to_owned(), &artist.name.to_owned());
+            app.get_artist(&artist.id, &artist.name);
+            app.push_navigation_stack(RouteId::Artist, ActiveBlock::ArtistBlock);
         }
         Key::Char('D') => app.user_unfollow_artists(),
         _ => {}

--- a/src/handlers/common_key_events.rs
+++ b/src/handlers/common_key_events.rs
@@ -64,66 +64,62 @@ pub fn on_up_press_handler<T>(selection_data: &[T], selection_index: Option<usiz
 
 pub fn handle_right_event(app: &mut App) {
     match app.get_current_route().hovered_block {
-        ActiveBlock::MyPlaylists | ActiveBlock::Library => {
-            match app.get_current_route().id {
-                RouteId::AlbumTracks => {
-                    app.set_current_route_state(
-                        Some(ActiveBlock::AlbumTracks),
-                        Some(ActiveBlock::AlbumTracks),
-                    );
-                }
-                RouteId::TrackTable => {
-                    app.set_current_route_state(
-                        Some(ActiveBlock::TrackTable),
-                        Some(ActiveBlock::TrackTable),
-                    );
-                }
-                RouteId::Podcasts => {
-                    app.set_current_route_state(
-                        Some(ActiveBlock::Podcasts),
-                        Some(ActiveBlock::Podcasts),
-                    );
-                }
-                RouteId::AlbumList => {
-                    app.set_current_route_state(
-                        Some(ActiveBlock::AlbumList),
-                        Some(ActiveBlock::AlbumList),
-                    );
-                }
-                RouteId::MadeForYou => {
-                    app.set_current_route_state(
-                        Some(ActiveBlock::MadeForYou),
-                        Some(ActiveBlock::MadeForYou),
-                    );
-                }
-                RouteId::Artists => {
-                    app.set_current_route_state(
-                        Some(ActiveBlock::Artists),
-                        Some(ActiveBlock::Artists),
-                    );
-                }
-                RouteId::RecentlyPlayed => {
-                    app.set_current_route_state(
-                        Some(ActiveBlock::RecentlyPlayed),
-                        Some(ActiveBlock::RecentlyPlayed),
-                    );
-                }
-                RouteId::Search => {
-                    app.set_current_route_state(
-                        Some(ActiveBlock::SearchResultBlock),
-                        Some(ActiveBlock::SearchResultBlock),
-                    );
-                }
-                RouteId::Artist => {
-                    // TODO
-                }
-                RouteId::Home => {
-                    app.set_current_route_state(Some(ActiveBlock::Home), Some(ActiveBlock::Home));
-                }
-                RouteId::SelectedDevice => {}
-                RouteId::Error => {}
+        ActiveBlock::MyPlaylists | ActiveBlock::Library => match app.get_current_route().id {
+            RouteId::AlbumTracks => {
+                app.set_current_route_state(
+                    Some(ActiveBlock::AlbumTracks),
+                    Some(ActiveBlock::AlbumTracks),
+                );
             }
-        }
+            RouteId::TrackTable => {
+                app.set_current_route_state(
+                    Some(ActiveBlock::TrackTable),
+                    Some(ActiveBlock::TrackTable),
+                );
+            }
+            RouteId::Podcasts => {
+                app.set_current_route_state(
+                    Some(ActiveBlock::Podcasts),
+                    Some(ActiveBlock::Podcasts),
+                );
+            }
+            RouteId::AlbumList => {
+                app.set_current_route_state(
+                    Some(ActiveBlock::AlbumList),
+                    Some(ActiveBlock::AlbumList),
+                );
+            }
+            RouteId::MadeForYou => {
+                app.set_current_route_state(
+                    Some(ActiveBlock::MadeForYou),
+                    Some(ActiveBlock::MadeForYou),
+                );
+            }
+            RouteId::Artists => {
+                app.set_current_route_state(Some(ActiveBlock::Artists), Some(ActiveBlock::Artists));
+            }
+            RouteId::RecentlyPlayed => {
+                app.set_current_route_state(
+                    Some(ActiveBlock::RecentlyPlayed),
+                    Some(ActiveBlock::RecentlyPlayed),
+                );
+            }
+            RouteId::Search => {
+                app.set_current_route_state(
+                    Some(ActiveBlock::SearchResultBlock),
+                    Some(ActiveBlock::SearchResultBlock),
+                );
+            }
+            RouteId::Artist => app.set_current_route_state(
+                Some(ActiveBlock::ArtistBlock),
+                Some(ActiveBlock::ArtistBlock),
+            ),
+            RouteId::Home => {
+                app.set_current_route_state(Some(ActiveBlock::Home), Some(ActiveBlock::Home));
+            }
+            RouteId::SelectedDevice => {}
+            RouteId::Error => {}
+        },
         _ => {}
     };
 }

--- a/src/handlers/empty.rs
+++ b/src/handlers/empty.rs
@@ -15,7 +15,7 @@ pub fn handler(key: Key, app: &mut App) {
             ActiveBlock::Library => {
                 app.set_current_route_state(None, Some(ActiveBlock::MyPlaylists));
             }
-            ActiveBlock::Artist
+            ActiveBlock::ArtistBlock
             | ActiveBlock::AlbumList
             | ActiveBlock::AlbumTracks
             | ActiveBlock::Artists
@@ -38,7 +38,7 @@ pub fn handler(key: Key, app: &mut App) {
             _ => {}
         },
         k if common_key_events::left_event(k) => match app.get_current_route().hovered_block {
-            ActiveBlock::Artist
+            ActiveBlock::ArtistBlock
             | ActiveBlock::AlbumList
             | ActiveBlock::AlbumTracks
             | ActiveBlock::Artists

--- a/src/handlers/search_results.rs
+++ b/src/handlers/search_results.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::app::{App, SearchResultBlock, TrackTableContext},
+    super::app::{ActiveBlock, App, RouteId, SearchResultBlock, TrackTableContext},
     common_key_events,
 };
 use crate::event::Key;
@@ -152,7 +152,8 @@ fn handle_enter_event_on_selected_block(app: &mut App) {
             if let Some(index) = &app.search_results.selected_artists_index {
                 if let Some(result) = app.search_results.artists.clone() {
                     if let Some(artist) = result.artists.items.get(index.to_owned()) {
-                        app.get_artist_albums(&artist.id, &artist.name);
+                        app.get_artist(&artist.id, &artist.name);
+                        app.push_navigation_stack(RouteId::Artist, ActiveBlock::ArtistBlock);
                     };
                 };
             };

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -1,4 +1,4 @@
-use super::super::app::{ActiveBlock, App, SearchResultBlock};
+use super::super::app::{ActiveBlock, App, ArtistBlock, SearchResultBlock};
 use rspotify::spotify::model::artist::SimplifiedArtist;
 use tui::style::{Color, Style};
 
@@ -12,6 +12,18 @@ pub fn get_search_results_highlight_state(
         current_route.hovered_block == ActiveBlock::SearchResultBlock
             && app.search_results.hovered_block == block_to_match,
     )
+}
+
+pub fn get_artist_highlight_state(app: &App, block_to_match: ArtistBlock) -> (bool, bool) {
+    let current_route = app.get_current_route();
+    if let Some(artist) = &app.artist {
+        let is_hovered = artist.artist_selected_block == block_to_match;
+        let is_selected = current_route.hovered_block == ActiveBlock::ArtistBlock
+            && artist.artist_hovered_block == block_to_match;
+        (is_hovered, is_selected)
+    } else {
+        (false, false)
+    }
 }
 
 pub fn get_color((is_active, is_hovered): (bool, bool)) -> Style {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,71 @@
+use std::{io::stdin, sync::mpsc, thread, time::Duration};
+use termion::{event::Key, input::TermRead};
+
+pub enum Event<I> {
+    Input(I),
+    Tick,
+}
+
+/// A small event handler that wrap termion input and tick events. Each event
+/// type is handled in its own thread and returned to a common `Receiver`
+pub struct Events {
+    rx: mpsc::Receiver<Event<Key>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Config {
+    pub exit_key: Key,
+    pub tick_rate: Duration,
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            exit_key: Key::Ctrl('c'),
+            tick_rate: Duration::from_millis(250),
+        }
+    }
+}
+
+impl Events {
+    pub fn new() -> Events {
+        Events::with_config(Config::default())
+    }
+
+    pub fn with_config(config: Config) -> Events {
+        let (tx, rx) = mpsc::channel();
+        let _input_handle = {
+            let tx = tx.clone();
+            thread::spawn(move || {
+                let stdin_result = stdin();
+                for evt in stdin_result.keys() {
+                    if let Ok(key) = evt {
+                        if tx.send(Event::Input(key)).is_err() {
+                            return;
+                        }
+                        if key == config.exit_key {
+                            return;
+                        }
+                    }
+                }
+            })
+        };
+
+        let _tick_handle = {
+            let tx = tx;
+            thread::spawn(move || {
+                let tx = tx.clone();
+                loop {
+                    tx.send(Event::Tick).unwrap();
+                    thread::sleep(config.tick_rate);
+                }
+            })
+        };
+
+        Events { rx }
+    }
+
+    pub fn next(&self) -> Result<Event<Key>, mpsc::RecvError> {
+        self.rx.recv()
+    }
+}


### PR DESCRIPTION
Selecting an artist in artists or search result view show the artist's album so far. In this PR, I modifed to show top tracks and related artists of the selected artist.

Before:
![before](https://user-images.githubusercontent.com/54503126/70843851-1aa4b000-1e7c-11ea-85ec-1f4e0ac2254d.png)

After:
![after](https://user-images.githubusercontent.com/54503126/70843855-1f696400-1e7c-11ea-9716-72e4cc8e7783.png)

