### PR TITLE
Disallow CTRL+d scroll past playlist end

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -239,7 +239,7 @@ pub struct App {
     pub library: Library,
     pub playlist_offset: u32,
     pub playback_params: PlaybackParams,
-    pub playlist_tracks: Vec<PlaylistTrack>,
+    pub playlist_tracks: Option<Page<PlaylistTrack>>,
     pub playlists: Option<Page<SimplifiedPlaylist>>,
     pub recently_played: SpotifyResultAndSelectedIndex<Option<CursorBasedPage<PlayHistory>>>,
     pub search_results: SearchResult,
@@ -291,7 +291,7 @@ impl App {
             input_idx: 0,
             input_cursor_position: 0,
             playlist_offset: 0,
-            playlist_tracks: vec![],
+            playlist_tracks: None,
             playlists: None,
             search_results: SearchResult {
                 hovered_block: SearchResultBlock::SongSearch,
@@ -619,7 +619,7 @@ impl App {
                 ) {
                     self.set_playlist_tracks_to_table(&playlist_tracks);
 
-                    self.playlist_tracks = playlist_tracks.items;
+                    self.playlist_tracks = Some(playlist_tracks);
                     if self.get_current_route().id != RouteId::TrackTable {
                         self.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
                     };

--- a/src/handlers/track_table.rs
+++ b/src/handlers/track_table.rs
@@ -114,9 +114,15 @@ pub fn handler(key: Key, app: &mut App) {
                             if let Some(selected_playlist) =
                                 playlists.items.get(selected_playlist_index.to_owned())
                             {
-                                app.playlist_offset += app.large_search_limit;
-                                let playlist_id = selected_playlist.id.to_owned();
-                                app.get_playlist_tracks(playlist_id);
+                                if let Some(playlist_tracks) = &app.playlist_tracks {
+                                    if app.playlist_offset + app.large_search_limit
+                                        < playlist_tracks.total
+                                    {
+                                        app.playlist_offset += app.large_search_limit;
+                                        let playlist_id = selected_playlist.id.to_owned();
+                                        app.get_playlist_tracks(playlist_id);
+                                    }
+                                }
                             }
                         };
                     }


### PR DESCRIPTION
Addresses #192. 

Previously, when using CTRL+d to page downwards on a playlist, there was no guard against incrementing the playlist offset past the end of the playlist, resulting in empty track tables. This commit checks if the track table is empty after attempting a CTRL+d scroll and backtracks to
the previous playlist offset.

From what I can tell, the Spotify API doesn't offer a way to get the total size of a playlist, so we can't just check before making a request whether we're about to scroll past the end (which would be ideal). This means that hitting CTRL+d at the end of a playlist results in two API requests (one to notice we got an empty response, and another to reload with the old limit), and consequently this implementation is a bit on the slow side.

I'm quite new to Rust, so please let me know if I've done anything barbarous :) 