### PR TITLE
Make behavior of previous button mimic behavior in official Spotify client

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -549,14 +549,18 @@ impl App {
 
     pub fn previous_track(&mut self) {
         if let (Some(spotify), Some(device_id)) = (&self.spotify, &self.client_config.device_id) {
-            match spotify.previous_track(Some(device_id.to_string())) {
-                Ok(()) => {
-                    self.get_current_playback();
-                }
-                Err(e) => {
-                    self.handle_error(e);
-                }
-            };
+            if self.song_progress_ms >= 3_000 {
+                self.seek(0);
+            } else {
+                match spotify.previous_track(Some(device_id.to_string())) {
+                    Ok(()) => {
+                        self.get_current_playback();
+                    }
+                    Err(e) => {
+                        self.handle_error(e);
+                    }
+                };
+            }
         }
     }
 


### PR DESCRIPTION
This PR mimics the behavior of the previous button in the official client by only going to the previous track if current track time is under three seconds.

Alternative to #215 
Closes #214 