### PR TITLE
Experimental audio visualiser

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ behavior:
   seek_milliseconds: 5000
   volume_increment: 10
   # The lower the number the higher the "frames per second". You can decrease this number so that the audio visualisation is smoother but this can be expensive!
-  tick_rate: 250
+  tick_rate_milliseconds: 250
 
 keybindings:
   # Key stroke can be used if it only uses two keys:

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ theme:
 behavior:
   seek_milliseconds: 5000
   volume_increment: 10
+  # The lower the number the higher the "frames per second". You can decrease this number so that the audio visualisation is smoother but this can be expensive!
+  tick_rate: 250
 
 keybindings:
   # Key stroke can be used if it only uses two keys:

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -38,8 +38,11 @@ pub struct Events {
 
 impl Events {
     /// Constructs an new instance of `Events` with the default config.
-    pub fn new() -> Events {
-        Events::with_config(EventConfig::default())
+    pub fn new(tick_rate: u64) -> Events {
+        Events::with_config(EventConfig {
+            tick_rate: Duration::from_millis(tick_rate),
+            ..Default::default()
+        })
     }
 
     /// Constructs an new instance of `Events` from given config.

--- a/src/handlers/analysis.rs
+++ b/src/handlers/analysis.rs
@@ -1,0 +1,7 @@
+use crate::{app::App, event::Key};
+
+pub fn handler(key: Key, _app: &mut App) {
+    match key {
+        _ => {}
+    };
+}

--- a/src/handlers/common_key_events.rs
+++ b/src/handlers/common_key_events.rs
@@ -161,6 +161,7 @@ pub fn handle_right_event(app: &mut App) {
             }
             RouteId::SelectedDevice => {}
             RouteId::Error => {}
+            RouteId::Analysis => {}
         },
         _ => {}
     };

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,5 +1,6 @@
 mod album_list;
 mod album_tracks;
+mod analysis;
 mod artist;
 mod artists;
 mod common_key_events;
@@ -79,6 +80,9 @@ pub fn handle_app(key: Key, app: &mut App) {
         _ if key == app.user_config.keys.copy_album_url => {
             app.copy_album_url();
         }
+        Key::Char('v') => {
+            app.get_audio_analysis();
+        }
         _ => handle_block_events(key, app),
     }
 }
@@ -87,6 +91,9 @@ pub fn handle_app(key: Key, app: &mut App) {
 fn handle_block_events(key: Key, app: &mut App) {
     let current_route = app.get_current_route();
     match current_route.active_block {
+        ActiveBlock::Analysis => {
+            analysis::handler(key, app);
+        }
         ActiveBlock::ArtistBlock => {
             artist::handler(key, app);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,7 +169,7 @@ fn main() -> Result<(), failure::Error> {
             let mut terminal = Terminal::new(backend)?;
             terminal.hide_cursor()?;
 
-            let events = event::Events::new();
+            let events = event::Events::new(user_config.behavior.tick_rate);
 
             // Initialise app state
             let mut app = App::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,9 @@ fn main() -> Result<(), failure::Error> {
                     ActiveBlock::SelectDevice => {
                         ui::draw_device_list(&mut f, &app);
                     }
+                    ActiveBlock::Analysis => {
+                        ui::draw_analysis(&mut f, &app);
+                    }
                     _ => {
                         ui::draw_main_layout(&mut f, &app);
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ fn main() -> Result<(), failure::Error> {
          .arg(Arg::with_name("tick-rate")
                                .short("t")
                                .long("tick-rate")
-                               .help("Set the tick rate: the lower the number the higher the FPS. It can be nicer to have a lower value when you want to use the audio analysis view of the app. Beware that this comes at a CPU cost!")
+                               .help("Set the tick rate (milliseconds): the lower the number the higher the FPS. It can be nicer to have a lower value when you want to use the audio analysis view of the app. Beware that this comes at a CPU cost!")
                                .takes_value(true))
         .get_matches();
 
@@ -153,7 +153,11 @@ fn main() -> Result<(), failure::Error> {
         .value_of("tick-rate")
         .and_then(|tick_rate| tick_rate.parse().ok())
     {
-        user_config.behavior.tick_rate = tick_rate;
+        if tick_rate >= 1000 {
+            panic!("Tick rate must be below 1000");
+        } else {
+            user_config.behavior.tick_rate_milliseconds = tick_rate;
+        }
     }
 
     let mut client_config = ClientConfig::new();
@@ -181,7 +185,7 @@ fn main() -> Result<(), failure::Error> {
             let mut terminal = Terminal::new(backend)?;
             terminal.hide_cursor()?;
 
-            let events = event::Events::new(user_config.behavior.tick_rate);
+            let events = event::Events::new(user_config.behavior.tick_rate_milliseconds);
 
             // Initialise app state
             let mut app = App::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use crate::event::Key;
 use app::{ActiveBlock, App};
 use backtrace::Backtrace;
 use banner::BANNER;
-use clap::App as ClapApp;
+use clap::{App as ClapApp, Arg};
 use config::ClientConfig;
 use crossterm::{
     cursor::MoveTo,
@@ -132,17 +132,29 @@ fn main() -> Result<(), failure::Error> {
         panic_hook(info);
     }));
 
-    ClapApp::new(env!("CARGO_PKG_NAME"))
+    let matches = ClapApp::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
         .author(env!("CARGO_PKG_AUTHORS"))
         .about(env!("CARGO_PKG_DESCRIPTION"))
         .usage("Press `?` while running the app to see keybindings")
         .before_help(BANNER)
         .after_help("Your spotify Client ID and Client Secret are stored in $HOME/.config/spotify-tui/client.yml")
+         .arg(Arg::with_name("tick-rate")
+                               .short("t")
+                               .long("tick-rate")
+                               .help("Set the tick rate: the lower the number the higher the FPS. It can be nicer to have a lower value when you want to use the audio analysis view of the app. Beware that this comes at a CPU cost!")
+                               .takes_value(true))
         .get_matches();
 
     let mut user_config = UserConfig::new();
     user_config.load_config()?;
+
+    if let Some(tick_rate) = matches
+        .value_of("tick-rate")
+        .and_then(|tick_rate| tick_rate.parse().ok())
+    {
+        user_config.behavior.tick_rate = tick_rate;
+    }
 
     let mut client_config = ClientConfig::new();
     client_config.load_config()?;
@@ -216,7 +228,7 @@ fn main() -> Result<(), failure::Error> {
                         ui::draw_device_list(&mut f, &app);
                     }
                     ActiveBlock::Analysis => {
-                        ui::draw_analysis(&mut f, &app);
+                        ui::audio_analysis::draw(&mut f, &app);
                     }
                     _ => {
                         ui::draw_main_layout(&mut f, &app);

--- a/src/ui/audio_analysis.rs
+++ b/src/ui/audio_analysis.rs
@@ -1,0 +1,115 @@
+use crate::app::App;
+use tui::{
+    backend::Backend,
+    layout::{Constraint, Direction, Layout},
+    style::Style,
+    widgets::{BarChart, Block, Borders, Paragraph, Text, Widget},
+    Frame,
+};
+const PITCHES: [&str; 12] = [
+    "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B",
+];
+
+pub fn draw<B>(f: &mut Frame<B>, app: &App)
+where
+    B: Backend,
+{
+    if let Some(analysis) = &app.audio_analysis {
+        let progress_seconds = (app.song_progress_ms as f32) / 1000.0;
+
+        let beat = analysis
+            .beats
+            .iter()
+            .find(|beat| beat.start >= progress_seconds);
+
+        let beat_offset = beat
+            .map(|beat| beat.start - progress_seconds)
+            .unwrap_or(0.0);
+        let segment = analysis
+            .segments
+            .iter()
+            .find(|segment| segment.start >= progress_seconds);
+        let section = analysis
+            .sections
+            .iter()
+            .find(|section| section.start >= progress_seconds);
+
+        if let (Some(segment), Some(section)) = (segment, section) {
+            let data: Vec<(&str, u64)> = segment
+                .pitches
+                .iter()
+                .enumerate()
+                .map(|(index, pitch)| {
+                    let display_pitch = *PITCHES.get(index).unwrap_or(&PITCHES[0]);
+                    let bar_value = ((pitch * 1000.0) as u64)
+                        // Add a beat offset to make the bar animate between beats
+                        .checked_add((beat_offset * 3000.0) as u64)
+                        .unwrap_or(0);
+
+                    (display_pitch, bar_value)
+                })
+                .collect();
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Percentage(10), Constraint::Percentage(90)].as_ref())
+                .margin(2)
+                .split(f.size());
+
+            let analysis_block = Block::default()
+                .title("Analysis")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(app.user_config.theme.inactive))
+                .title_style(Style::default().fg(app.user_config.theme.inactive));
+
+            Paragraph::new(
+                [
+                    Text::raw(format!(
+                        "Tempo: {} (confidence {:.0}%)\n",
+                        section.tempo,
+                        section.tempo_confidence * 100.0
+                    )),
+                    Text::raw(format!(
+                        "Key: {} (confidence {:.0}%)\n",
+                        PITCHES.get(section.key as usize).unwrap_or(&PITCHES[0]),
+                        section.key_confidence * 100.0
+                    )),
+                    Text::raw(format!(
+                        "Time Signature: {}/4 (confidence {:.0}%)\n",
+                        section.time_signature,
+                        section.time_signature_confidence * 100.0
+                    )),
+                ]
+                .iter(),
+            )
+            .block(analysis_block)
+            .style(Style::default().fg(app.user_config.theme.text))
+            .render(f, chunks[0]);
+
+            let white = Style::default().fg(app.user_config.theme.text);
+            let gray = Style::default().fg(app.user_config.theme.inactive);
+            let width = f.size().width / PITCHES.len() as u16;
+            BarChart::default()
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .style(white)
+                        .title(&format!(
+                            "Pitches | Tick Rate {}",
+                            app.user_config.behavior.tick_rate
+                        ))
+                        .title_style(gray)
+                        .border_style(gray),
+                )
+                .data(&data)
+                .bar_width(width)
+                .bar_gap(1)
+                .style(Style::default().fg(app.user_config.theme.analysis_bar))
+                .value_style(
+                    Style::default()
+                        .fg(app.user_config.theme.analysis_bar_text)
+                        .bg(app.user_config.theme.analysis_bar),
+                )
+                .render(f, chunks[1]);
+        };
+    }
+}

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -42,6 +42,7 @@ pub fn get_help_docs() -> Vec<Vec<&'static str>> {
         vec!["Enter input for search", "/", "General"],
         vec!["Pause/Resume playback", "<Space>", "General"],
         vec!["Enter active mode", "<Enter>", "General"],
+        vec!["Go to audio analysis screen", "v", "General"],
         vec![
             "Go back or exit when nowhere left to back to",
             "q",

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -94,28 +94,65 @@ where
             .segments
             .iter()
             .find(|segment| segment.start >= progress_seconds);
+        let section = analysis
+            .sections
+            .iter()
+            .find(|section| section.start >= progress_seconds);
 
-        if let Some(segment) = segment {
+        if let (Some(segment), Some(section)) = (segment, section) {
             let data: Vec<(&str, u64)> = segment
                 .pitches
                 .iter()
                 .enumerate()
                 .map(|(index, pitch)| {
-                    (
-                        *PITCHES.get(index).unwrap_or(&PITCHES[0]),
-                        ((pitch * 1000.0) as u64)
-                            .checked_add((beat_offset * 3000.0) as u64)
-                            .unwrap_or(0),
-                    )
+                    let display_pitch = *PITCHES.get(index).unwrap_or(&PITCHES[0]);
+                    let bar_value = ((pitch * 1000.0) as u64)
+                        // Add a beat offset to make the bar animate between beats
+                        .checked_add((beat_offset * 3000.0) as u64)
+                        .unwrap_or(0);
+
+                    (display_pitch, bar_value)
                 })
                 .collect();
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints([Constraint::Percentage(100)].as_ref())
+                .constraints([Constraint::Percentage(10), Constraint::Percentage(90)].as_ref())
                 .margin(2)
                 .split(f.size());
+
+            let analysis_block = Block::default()
+                .title("Analysis")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(app.user_config.theme.inactive))
+                .title_style(Style::default().fg(app.user_config.theme.inactive));
+
+            Paragraph::new(
+                [
+                    Text::raw(format!(
+                        "Tempo: {} (confidence {:.0}%)\n",
+                        section.tempo,
+                        section.tempo_confidence * 100.0
+                    )),
+                    Text::raw(format!(
+                        "Key: {} (confidence {:.0}%)\n",
+                        PITCHES.get(section.key as usize).unwrap_or(&PITCHES[0]),
+                        section.key_confidence * 100.0
+                    )),
+                    Text::raw(format!(
+                        "Time Signature: {}/4 (confidence {:.0}%)\n",
+                        section.time_signature,
+                        section.time_signature_confidence * 100.0
+                    )),
+                ]
+                .iter(),
+            )
+            .block(analysis_block)
+            .style(Style::default().fg(app.user_config.theme.text))
+            .render(f, chunks[0]);
+
             let white = Style::default().fg(app.user_config.theme.text);
-            let gray = Style::default().fg(app.user_config.theme.text);
+            let gray = Style::default().fg(app.user_config.theme.inactive);
+            let width = f.size().width / PITCHES.len() as u16;
             BarChart::default()
                 .block(
                     Block::default()
@@ -126,10 +163,15 @@ where
                         .border_style(gray),
                 )
                 .data(&data)
-                .bar_width(9)
-                .style(Style::default().fg(Color::Yellow))
-                .value_style(Style::default().fg(Color::Black).bg(Color::Yellow))
-                .render(f, chunks[0]);
+                .bar_width(width)
+                .bar_gap(1)
+                .style(Style::default().fg(app.user_config.theme.analysis_bar))
+                .value_style(
+                    Style::default()
+                        .fg(app.user_config.theme.analysis_bar_text)
+                        .bg(app.user_config.theme.analysis_bar),
+                )
+                .render(f, chunks[1]);
         };
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -158,7 +158,10 @@ where
                     Block::default()
                         .borders(Borders::ALL)
                         .style(white)
-                        .title("Pitches")
+                        .title(&format!(
+                            "Pitches | Tick Rate {}",
+                            app.user_config.behavior.tick_rate
+                        ))
                         .title_style(gray)
                         .border_style(gray),
                 )

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,4 @@
+pub mod audio_analysis;
 mod help;
 mod util;
 use super::{
@@ -12,10 +13,8 @@ use rspotify::spotify::senum::RepeatState;
 use tui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
-    widgets::{
-        BarChart, Block, Borders, Gauge, Paragraph, Row, SelectableList, Table, Text, Widget,
-    },
+    style::{Modifier, Style},
+    widgets::{Block, Borders, Gauge, Paragraph, Row, SelectableList, Table, Text, Widget},
     Frame,
 };
 use util::{
@@ -69,114 +68,6 @@ pub struct TableHeaderItem<'a> {
 pub struct TableItem {
     id: String,
     format: Vec<String>,
-}
-
-const PITCHES: [&str; 12] = [
-    "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B",
-];
-
-pub fn draw_analysis<B>(f: &mut Frame<B>, app: &App)
-where
-    B: Backend,
-{
-    if let Some(analysis) = &app.audio_analysis {
-        let progress_seconds = (app.song_progress_ms as f32) / 1000.0;
-
-        let beat = analysis
-            .beats
-            .iter()
-            .find(|beat| beat.start >= progress_seconds);
-
-        let beat_offset = beat
-            .map(|beat| beat.start - progress_seconds)
-            .unwrap_or(0.0);
-        let segment = analysis
-            .segments
-            .iter()
-            .find(|segment| segment.start >= progress_seconds);
-        let section = analysis
-            .sections
-            .iter()
-            .find(|section| section.start >= progress_seconds);
-
-        if let (Some(segment), Some(section)) = (segment, section) {
-            let data: Vec<(&str, u64)> = segment
-                .pitches
-                .iter()
-                .enumerate()
-                .map(|(index, pitch)| {
-                    let display_pitch = *PITCHES.get(index).unwrap_or(&PITCHES[0]);
-                    let bar_value = ((pitch * 1000.0) as u64)
-                        // Add a beat offset to make the bar animate between beats
-                        .checked_add((beat_offset * 3000.0) as u64)
-                        .unwrap_or(0);
-
-                    (display_pitch, bar_value)
-                })
-                .collect();
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Percentage(10), Constraint::Percentage(90)].as_ref())
-                .margin(2)
-                .split(f.size());
-
-            let analysis_block = Block::default()
-                .title("Analysis")
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(app.user_config.theme.inactive))
-                .title_style(Style::default().fg(app.user_config.theme.inactive));
-
-            Paragraph::new(
-                [
-                    Text::raw(format!(
-                        "Tempo: {} (confidence {:.0}%)\n",
-                        section.tempo,
-                        section.tempo_confidence * 100.0
-                    )),
-                    Text::raw(format!(
-                        "Key: {} (confidence {:.0}%)\n",
-                        PITCHES.get(section.key as usize).unwrap_or(&PITCHES[0]),
-                        section.key_confidence * 100.0
-                    )),
-                    Text::raw(format!(
-                        "Time Signature: {}/4 (confidence {:.0}%)\n",
-                        section.time_signature,
-                        section.time_signature_confidence * 100.0
-                    )),
-                ]
-                .iter(),
-            )
-            .block(analysis_block)
-            .style(Style::default().fg(app.user_config.theme.text))
-            .render(f, chunks[0]);
-
-            let white = Style::default().fg(app.user_config.theme.text);
-            let gray = Style::default().fg(app.user_config.theme.inactive);
-            let width = f.size().width / PITCHES.len() as u16;
-            BarChart::default()
-                .block(
-                    Block::default()
-                        .borders(Borders::ALL)
-                        .style(white)
-                        .title(&format!(
-                            "Pitches | Tick Rate {}",
-                            app.user_config.behavior.tick_rate
-                        ))
-                        .title_style(gray)
-                        .border_style(gray),
-                )
-                .data(&data)
-                .bar_width(width)
-                .bar_gap(1)
-                .style(Style::default().fg(app.user_config.theme.analysis_bar))
-                .value_style(
-                    Style::default()
-                        .fg(app.user_config.theme.analysis_bar_text)
-                        .bg(app.user_config.theme.analysis_bar),
-                )
-                .render(f, chunks[1]);
-        };
-    }
 }
 
 pub fn draw_help_menu<B>(f: &mut Frame<B>, app: &App)

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -194,6 +194,7 @@ pub struct BehaviorConfigString {
 pub struct BehaviorConfig {
     pub seek_milliseconds: u32,
     pub volume_increment: u8,
+    pub tick_rate: u64,
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -236,6 +237,7 @@ impl UserConfig {
             behavior: BehaviorConfig {
                 seek_milliseconds: 5 * 1000,
                 volume_increment: 10,
+                tick_rate: 250,
             },
         }
     }

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -189,12 +189,13 @@ pub struct KeyBindings {
 pub struct BehaviorConfigString {
     pub seek_milliseconds: Option<u32>,
     pub volume_increment: Option<u8>,
+    pub tick_rate_milliseconds: Option<u64>,
 }
 
 pub struct BehaviorConfig {
     pub seek_milliseconds: u32,
     pub volume_increment: u8,
-    pub tick_rate: u64,
+    pub tick_rate_milliseconds: u64,
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -237,7 +238,7 @@ impl UserConfig {
             behavior: BehaviorConfig {
                 seek_milliseconds: 5 * 1000,
                 volume_increment: 10,
-                tick_rate: 250,
+                tick_rate_milliseconds: 250,
             },
         }
     }
@@ -344,6 +345,14 @@ impl UserConfig {
                 ));
             }
             self.behavior.volume_increment = behavior_string;
+        }
+
+        if let Some(tick_rate) = behavior_config.tick_rate_milliseconds {
+            if tick_rate >= 1000 {
+                return Err(err_msg("Tick rate must be below 1000"));
+            } else {
+                self.behavior.tick_rate_milliseconds = tick_rate;
+            }
         }
 
         Ok(())

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -30,6 +30,8 @@ pub struct UserTheme {
 
 #[derive(Copy, Clone, Debug)]
 pub struct Theme {
+    pub analysis_bar: Color,
+    pub analysis_bar_text: Color,
     pub active: Color,
     pub banner: Color,
     pub error_border: Color,
@@ -47,6 +49,8 @@ pub struct Theme {
 impl Default for Theme {
     fn default() -> Self {
         Theme {
+            analysis_bar: Color::LightCyan,
+            analysis_bar_text: Color::Black,
             active: Color::Cyan,
             banner: Color::LightCyan,
             error_border: Color::Red,


### PR DESCRIPTION
The spotify API has a [audio analysis endpoint](https://developer.spotify.com/documentation/web-api/reference/tracks/get-audio-analysis/) for a given track.

This is an experimental attempt to use that data to "visualise" a track using a bar chart.

### Gif demo
![spotify-tui-visualisation](https://user-images.githubusercontent.com/12150276/74425718-0b29ef00-4e4c-11ea-8786-57358a672307.gif)

### Image
<img width="1680" alt="Screenshot 2020-02-12 at 18 52 32" src="https://user-images.githubusercontent.com/12150276/74371269-6ae2b480-4dd0-11ea-8764-a8b2a2943db9.png">

## How does this work?
This is very basic but the visualisation is based on the "pitch" information for a given "section" of the piece. To make things more animated, in between the section data I create an offset and subtract from the pitch information based on the current beat.

You can now also configure the `tick_rate` of the app. The lower this number the smoother the animations are. But this comes at a cost of higher CPU usage!

## TODO

- [x] Add `v` binding to go to visualisation screen
- [x] Make `tick_rate` configurable via cli arg and config.yml
- [x] Add colors for visualisation to user theme config
