### PR TITLE
Modify instruction to install with snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,16 @@ brew upgrade spotify-tui
 For a system with Snap installed, run
 
 ```bash
-snap install spt --channel=edge
+snap install spt
 ```
 
-The latest version will be installed for you automatically.
+The stable version will be installed for you automatically.
+
+If you want to install the nightly build, run
+
+```bash
+snap install spt --edge
+```
 
 ### AUR
 


### PR DESCRIPTION
Thanks to contibutions by @popey, @AivreeG, and @hurricanehrndz, we can install `spt` with `snap`.

However, the instruction written in `README` is not updated.
Here, I updated the instruction to install stable version of `spt` with `snap` and add a new instruction to install nightly build of it.