### PR TITLE
Add pagination to the help menu

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1339,7 +1339,7 @@ impl App {
         let old_offset = self.help_menu_offset;
 
         if self.help_menu_max_lines < self.help_docs_size {
-            self.help_menu_offset = self.help_menu_page * self.help_menu_max_lines + 1;
+            self.help_menu_offset = self.help_menu_page * self.help_menu_max_lines;
         }
         if self.help_menu_offset > self.help_docs_size {
             self.help_menu_offset = old_offset;

--- a/src/app.rs
+++ b/src/app.rs
@@ -287,6 +287,10 @@ pub struct App {
     pub made_for_you_index: usize,
     pub artists_list_index: usize,
     pub clipboard_context: Option<ClipboardContext>,
+    pub help_docs_size: u32,
+    pub help_menu_page: u32,
+    pub help_menu_max_lines: u32,
+    pub help_menu_offset: u32,
 }
 
 impl App {
@@ -357,6 +361,10 @@ impl App {
             user: None,
             instant_since_last_current_playback_poll: Instant::now(),
             clipboard_context: None,
+            help_docs_size: 0,
+            help_menu_page: 0,
+            help_menu_max_lines: 0,
+            help_menu_offset: 0,
         }
     }
 
@@ -1324,6 +1332,18 @@ impl App {
                     }
                 }
             }
+        }
+    }
+
+    pub fn calculate_help_menu_offset(&mut self) {
+        let old_offset = self.help_menu_offset;
+
+        if self.help_menu_max_lines < self.help_docs_size {
+            self.help_menu_offset = self.help_menu_page * self.help_menu_max_lines + 1;
+        }
+        if self.help_menu_offset > self.help_docs_size {
+            self.help_menu_offset = old_offset;
+            self.help_menu_page -= 1;
         }
     }
 }

--- a/src/handlers/help_menu.rs
+++ b/src/handlers/help_menu.rs
@@ -1,17 +1,37 @@
 use crate::{app::App, event::Key};
+use super::common_key_events;
+
+#[derive(PartialEq)]
+enum Direction {
+    UP,
+    DOWN,
+}
 
 pub fn handler(key: Key, app: &mut App) {
     match key {
+        k if common_key_events::down_event(k) => {
+            move_page(Direction::DOWN, app);
+        }
+        k if common_key_events::up_event(k) => {
+            move_page(Direction::UP, app);
+        }
         Key::Ctrl('d') => {
-            app.help_menu_page += 1;
-            app.calculate_help_menu_offset();
+            move_page(Direction::DOWN, app);
         }
         Key::Ctrl('u') => {
-            if app.help_menu_page > 0 {
-                app.help_menu_page -= 1;
-                app.calculate_help_menu_offset();
-            }
+            move_page(Direction::UP, app);
         }
         _ => {}
     };
+}
+
+fn move_page(direction: Direction, app: &mut App) {
+    if direction == Direction::UP {
+        if app.help_menu_page > 0 {
+            app.help_menu_page -= 1;
+        }
+    } else if direction == Direction::DOWN {
+        app.help_menu_page += 1;
+    }
+    app.calculate_help_menu_offset();
 }

--- a/src/handlers/help_menu.rs
+++ b/src/handlers/help_menu.rs
@@ -1,7 +1,17 @@
 use crate::{app::App, event::Key};
 
-pub fn handler(key: Key, _app: &mut App) {
+pub fn handler(key: Key, app: &mut App) {
     match key {
+        Key::Ctrl('d') => {
+           app.help_menu_page += 1; 
+           app.calculate_help_menu_offset();
+        }
+        Key::Ctrl('u') => {
+            if app.help_menu_page > 0 {
+                app.help_menu_page -= 1;
+                app.calculate_help_menu_offset();
+            }
+        }
         _ => {}
     };
 }

--- a/src/handlers/help_menu.rs
+++ b/src/handlers/help_menu.rs
@@ -3,8 +3,8 @@ use crate::{app::App, event::Key};
 pub fn handler(key: Key, app: &mut App) {
     match key {
         Key::Ctrl('d') => {
-           app.help_menu_page += 1; 
-           app.calculate_help_menu_offset();
+            app.help_menu_page += 1;
+            app.calculate_help_menu_offset();
         }
         Key::Ctrl('u') => {
             if app.help_menu_page > 0 {

--- a/src/handlers/help_menu.rs
+++ b/src/handlers/help_menu.rs
@@ -1,5 +1,5 @@
-use crate::{app::App, event::Key};
 use super::common_key_events;
+use crate::{app::App, event::Key};
 
 #[derive(PartialEq)]
 enum Direction {

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,8 +227,8 @@ fn main() -> Result<(), failure::Error> {
                     app.large_search_limit = min((f32::from(size.height) / 1.4) as u32, max_limit);
                     app.small_search_limit =
                         min((f32::from(size.height) / 2.85) as u32, max_limit / 2);
-                    
-                    // Based on the size of the terminal, adjust how many lines are 
+
+                    // Based on the size of the terminal, adjust how many lines are
                     // dislayed in the help menu
                     if app.size.height > 8 {
                         app.help_menu_max_lines = (app.size.height as u32) - 8;

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,6 +199,8 @@ fn main() -> Result<(), failure::Error> {
 
             app.clipboard_context = clipboard::ClipboardProvider::new().ok();
 
+            app.help_docs_size = ui::help::get_help_docs().len() as u32;
+
             // Now that spotify is ready, check if the user has already selected a device_id to
             // play music on, if not send them to the device selection view
             if app.client_config.device_id.is_none() {
@@ -210,6 +212,13 @@ fn main() -> Result<(), failure::Error> {
             loop {
                 // Get the size of the screen on each loop to account for resize event
                 if let Ok(size) = terminal.backend().size() {
+                    // Reset the help menu is the terminal was resized
+                    if app.size != size {
+                        app.help_menu_max_lines = 0;
+                        app.help_menu_offset = 0;
+                        app.help_menu_page = 0;
+                    }
+
                     app.size = size;
 
                     // Based on the size of the terminal, adjust the search limit.
@@ -218,6 +227,14 @@ fn main() -> Result<(), failure::Error> {
                     app.large_search_limit = min((f32::from(size.height) / 1.4) as u32, max_limit);
                     app.small_search_limit =
                         min((f32::from(size.height) / 2.85) as u32, max_limit / 2);
+                    
+                    // Based on the size of the terminal, adjust how many lines are 
+                    // dislayed in the help menu
+                    if app.size.height > 8 {
+                        app.help_menu_max_lines = (app.size.height as u32) - 8;
+                    } else {
+                        app.help_menu_max_lines = 0;
+                    }
                 };
 
                 let current_route = app.get_current_route();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,5 @@
 pub mod audio_analysis;
-mod help;
+pub mod help;
 mod util;
 use super::{
     app::{
@@ -85,6 +85,7 @@ where
     let header = ["Description", "Event", "Context"];
 
     let help_docs = get_help_docs();
+    let help_docs = &help_docs[app.help_menu_offset as usize..];
 
     let rows = help_docs
         .iter()


### PR DESCRIPTION
Fixed issue #301 by adding the ability to split the help menu into pages. The help menu can be navigated in a similar manner to the track list (Ctrl+D and Ctrl+U). 