### PR TITLE
Create a thread for network events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ name = "failure_derive"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -510,7 +510,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -807,6 +807,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-named-pipes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mio-uds"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "miow"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +836,15 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -980,7 +1010,7 @@ name = "pin-project-internal"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1010,7 +1040,7 @@ name = "proc-macro-hack"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1030,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1054,7 +1084,7 @@ name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1281,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "rspotify"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1375,7 +1405,7 @@ name = "serde_derive"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1442,6 +1472,17 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "socket2"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sourcefile"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,10 +1497,12 @@ dependencies = [
  "crossterm 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rspotify 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rspotify 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tui 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1489,7 +1532,7 @@ name = "syn"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1499,7 +1542,7 @@ name = "synstructure"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1562,11 +1605,27 @@ dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1746,7 +1805,7 @@ dependencies = [
  "bumpalo 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1777,7 +1836,7 @@ name = "wasm-bindgen-macro-support"
 version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1797,7 +1856,7 @@ dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2023,7 +2082,10 @@ dependencies = [
 "checksum mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "dd1d63acd1b78403cc0c325605908475dd9b9a3acbf65ed8bcab97e27014afcf"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
+"checksum mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
+"checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
@@ -2049,7 +2111,7 @@ dependencies = [
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
+"checksum proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
@@ -2075,7 +2137,7 @@ dependencies = [
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0e798e19e258bf6c30a304622e3e9ac820e483b06a1857a026e1f109b113fe4"
-"checksum rspotify 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a924a166cfb1315c8d9c89148e438a1337feb655ce052fc6dc952af8018bad93"
+"checksum rspotify 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29b79da3557219b1ea44609ae2bdddbe8f0cc71188ab863cc47d98e8a1d6eb5"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
@@ -2093,6 +2155,7 @@ dependencies = [
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
+"checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
@@ -2105,6 +2168,7 @@ dependencies = [
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8fdd17989496f49cdc57978c96f0c9fe5e4a58a8bddc6813c449a4624f6a030b"
+"checksum tokio-macros 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 "checksum tokio-socks 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45a756c74d51f7a835277695059aed2bc7399978eb1230dd8b2989cbb5e9e392"
 "checksum tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7bde02a3a5291395f59b06ec6945a3077602fac2b07eeeaf0dee2122f3619828"
 "checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rspotify = "0.8.0"
+rspotify = "0.9.0"
 tui = { version = "0.8.0", features = ["crossterm"], default-features = false }
 failure = "0.1.7"
 serde = { version = "1.0", features = ["derive"] }
@@ -26,6 +26,8 @@ unicode-width = "0.1.7"
 backtrace = "0.3.45"
 clipboard = "0.5.0"
 crossterm =  "0.16"
+tokio = { version = "0.2", features = ["full"] }
+proc-macro2 = "1.0.9"
 
 [[bin]]
 bench = false

--- a/src/handlers/album_list.rs
+++ b/src/handlers/album_list.rs
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn on_left_press() {
-        let mut app = App::new();
+        let mut app = App::default();
         app.set_current_route_state(
             Some(ActiveBlock::AlbumTracks),
             Some(ActiveBlock::AlbumTracks),
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn on_esc() {
-        let mut app = App::new();
+        let mut app = App::default();
 
         handler(Key::Esc, &mut app);
 

--- a/src/handlers/album_tracks.rs
+++ b/src/handlers/album_tracks.rs
@@ -2,6 +2,7 @@ use super::common_key_events;
 use crate::{
     app::{AlbumTableContext, App, RecommendationsContext},
     event::Key,
+    network::IoEvent,
 };
 
 pub fn handler(key: Key, app: &mut App) {
@@ -54,20 +55,20 @@ pub fn handler(key: Key, app: &mut App) {
         Key::Enter => match app.album_table_context {
             AlbumTableContext::Full => {
                 if let Some(selected_album) = app.selected_album_full.clone() {
-                    app.start_playback(
+                    app.dispatch(IoEvent::StartPlayback(
                         Some(selected_album.album.uri),
                         None,
                         Some(app.saved_album_tracks_index),
-                    );
+                    ));
                 };
             }
             AlbumTableContext::Simplified => {
                 if let Some(selected_album_simplified) = &app.selected_album_simplified.clone() {
-                    app.start_playback(
+                    app.dispatch(IoEvent::StartPlayback(
                         selected_album_simplified.album.uri.clone(),
                         None,
                         Some(selected_album_simplified.selected_index),
-                    );
+                    ));
                 };
             }
         },
@@ -148,7 +149,7 @@ fn handle_recommended_tracks(app: &mut App) {
                         if let Some(id) = &track.id {
                             app.recommendations_context = Some(RecommendationsContext::Song);
                             app.recommendations_seed = track.name.clone();
-                            app.get_recommendations_for_trackid(&id);
+                            app.get_recommendations_for_track_id(id.to_string());
                         }
                     }
                 }
@@ -164,7 +165,7 @@ fn handle_recommended_tracks(app: &mut App) {
                     if let Some(id) = &track.id {
                         app.recommendations_context = Some(RecommendationsContext::Song);
                         app.recommendations_seed = track.name.clone();
-                        app.get_recommendations_for_trackid(&id);
+                        app.get_recommendations_for_track_id(id.to_string());
                     }
                 }
             };
@@ -183,7 +184,7 @@ fn handle_save_event(app: &mut App) {
                     .get(app.saved_album_tracks_index)
                 {
                     if let Some(track_id) = &selected_track.id {
-                        app.toggle_save_track(track_id.clone());
+                        app.dispatch(IoEvent::ToggleSaveTrack(track_id.to_string()));
                     };
                 };
             };
@@ -196,7 +197,7 @@ fn handle_save_event(app: &mut App) {
                     .get(selected_album_simplified.selected_index)
                 {
                     if let Some(track_id) = &selected_track.id {
-                        app.toggle_save_track(track_id.clone());
+                        app.dispatch(IoEvent::ToggleSaveTrack(track_id.to_string()));
                     };
                 };
             };
@@ -211,7 +212,7 @@ mod tests {
 
     #[test]
     fn on_left_press() {
-        let mut app = App::new();
+        let mut app = App::default();
         app.set_current_route_state(
             Some(ActiveBlock::AlbumTracks),
             Some(ActiveBlock::AlbumTracks),
@@ -225,7 +226,7 @@ mod tests {
 
     #[test]
     fn on_esc() {
-        let mut app = App::new();
+        let mut app = App::default();
 
         handler(Key::Esc, &mut app);
 

--- a/src/handlers/artists.rs
+++ b/src/handlers/artists.rs
@@ -2,6 +2,7 @@ use super::common_key_events;
 use crate::{
     app::{ActiveBlock, App, RecommendationsContext, RouteId},
     event::Key,
+    network::IoEvent,
 };
 
 pub fn handler(key: Key, app: &mut App) {
@@ -46,7 +47,7 @@ pub fn handler(key: Key, app: &mut App) {
         Key::Enter => {
             let artists = app.artists.to_owned();
             let artist = &artists[app.artists_list_index];
-            app.get_artist(&artist.id, &artist.name);
+            app.get_artist(artist.id.clone(), artist.name.clone());
             app.push_navigation_stack(RouteId::Artist, ActiveBlock::ArtistBlock);
         }
         Key::Char('D') => app.user_unfollow_artists(),
@@ -54,7 +55,11 @@ pub fn handler(key: Key, app: &mut App) {
             let artists = app.artists.to_owned();
             let artist = artists.get(app.artists_list_index);
             if let Some(artist) = artist {
-                app.start_playback(Some(artist.uri.to_owned()), None, None);
+                app.dispatch(IoEvent::StartPlayback(
+                    Some(artist.uri.to_owned()),
+                    None,
+                    None,
+                ));
             }
         }
         Key::Char('r') => {

--- a/src/handlers/empty.rs
+++ b/src/handlers/empty.rs
@@ -62,7 +62,7 @@ mod tests {
 
     #[test]
     fn on_enter() {
-        let mut app = App::new();
+        let mut app = App::default();
 
         app.set_current_route_state(Some(ActiveBlock::Empty), Some(ActiveBlock::Library));
 
@@ -75,7 +75,7 @@ mod tests {
 
     #[test]
     fn on_down_press() {
-        let mut app = App::new();
+        let mut app = App::default();
 
         app.set_current_route_state(Some(ActiveBlock::Empty), Some(ActiveBlock::Library));
 
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn on_up_press() {
-        let mut app = App::new();
+        let mut app = App::default();
 
         app.set_current_route_state(Some(ActiveBlock::Empty), Some(ActiveBlock::MyPlaylists));
 
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn on_left_press() {
-        let mut app = App::new();
+        let mut app = App::default();
         app.set_current_route_state(Some(ActiveBlock::Empty), Some(ActiveBlock::AlbumTracks));
 
         handler(Key::Left, &mut app);
@@ -124,7 +124,7 @@ mod tests {
 
     #[test]
     fn on_right_press() {
-        let mut app = App::new();
+        let mut app = App::default();
 
         app.set_current_route_state(Some(ActiveBlock::Empty), Some(ActiveBlock::Library));
         app.push_navigation_stack(RouteId::AlbumTracks, ActiveBlock::AlbumTracks);

--- a/src/handlers/home.rs
+++ b/src/handlers/home.rs
@@ -35,7 +35,7 @@ mod tests {
 
     #[test]
     fn on_small_down_press() {
-        let mut app = App::new();
+        let mut app = App::default();
 
         handler(Key::Down, &mut app);
         assert_eq!(app.home_scroll, SMALL_SCROLL);
@@ -46,7 +46,7 @@ mod tests {
 
     #[test]
     fn on_small_up_press() {
-        let mut app = App::new();
+        let mut app = App::default();
 
         handler(Key::Up, &mut app);
         assert_eq!(app.home_scroll, 0);
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn on_large_down_press() {
-        let mut app = App::new();
+        let mut app = App::default();
 
         handler(Key::Ctrl('d'), &mut app);
         assert_eq!(app.home_scroll, LARGE_SCROLL);
@@ -76,7 +76,7 @@ mod tests {
 
     #[test]
     fn on_large_up_press() {
-        let mut app = App::new();
+        let mut app = App::default();
 
         let scroll = 37;
         app.home_scroll = scroll;

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -3,6 +3,7 @@ use super::{
     common_key_events,
 };
 use crate::event::Key;
+use crate::network::IoEvent;
 
 pub fn handler(key: Key, app: &mut App) {
     match key {
@@ -43,48 +44,20 @@ pub fn handler(key: Key, app: &mut App) {
             }
             // Recently Played,
             1 => {
-                if let Some(spotify) = &app.spotify {
-                    match spotify
-                        // Seems I need to clone here becuase `current_user_recently_played`
-                        // consumes `self`?
-                        .clone()
-                        .current_user_recently_played(app.large_search_limit)
-                    {
-                        Ok(result) => {
-                            app.recently_played.result = Some(result.clone());
-
-                            app.current_user_saved_tracks_contains(
-                                result
-                                    .items
-                                    .iter()
-                                    .filter_map(|item| item.track.id.clone())
-                                    .collect::<Vec<String>>(),
-                            );
-
-                            app.push_navigation_stack(
-                                RouteId::RecentlyPlayed,
-                                ActiveBlock::RecentlyPlayed,
-                            );
-                        }
-                        Err(e) => {
-                            app.handle_error(e);
-                        }
-                    }
-                };
+                app.dispatch(IoEvent::GetRecentlyPlayed);
             }
             // Liked Songs,
             2 => {
-                app.get_current_user_saved_tracks(None);
-                app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+                app.dispatch(IoEvent::GetCurrentSavedTracks(None, true));
             }
             // Albums,
             3 => {
-                app.get_current_user_saved_albums(Some(0));
+                app.dispatch(IoEvent::GetCurrentUserSavedAlbums(Some(0)));
                 app.push_navigation_stack(RouteId::AlbumList, ActiveBlock::AlbumList);
             }
             //  Artists,
             4 => {
-                app.get_artists(None);
+                app.dispatch(IoEvent::GetFollowedArtists(None));
                 app.push_navigation_stack(RouteId::Artists, ActiveBlock::Artists);
             }
             // Podcasts,

--- a/src/handlers/made_for_you.rs
+++ b/src/handlers/made_for_you.rs
@@ -3,6 +3,7 @@ use super::{
     common_key_events,
 };
 use crate::event::Key;
+use crate::network::IoEvent;
 
 pub fn handler(key: Key, app: &mut App) {
     match key {
@@ -57,7 +58,10 @@ pub fn handler(key: Key, app: &mut App) {
             {
                 app.made_for_you_offset = 0;
                 let playlist_id = selected_playlist.id.to_owned();
-                app.get_made_for_you_playlist_tracks(playlist_id);
+                app.dispatch(IoEvent::GetMadeForYouPlaylistTracks(
+                    playlist_id,
+                    app.made_for_you_offset,
+                ));
             }
         }
         _ => {}

--- a/src/handlers/playbar.rs
+++ b/src/handlers/playbar.rs
@@ -3,6 +3,7 @@ use super::{
     common_key_events,
 };
 use crate::event::Key;
+use crate::network::IoEvent;
 
 pub fn handler(key: Key, app: &mut App) {
     match key {
@@ -11,9 +12,9 @@ pub fn handler(key: Key, app: &mut App) {
         }
         Key::Char('s') => {
             if let Some(playing_context) = &app.current_playback_context {
-                if let Some(track) = &playing_context.item {
-                    if let Some(id) = track.id.to_owned() {
-                        app.toggle_save_track(id);
+                if let Some(track) = &playing_context.clone().item {
+                    if let Some(id) = &track.id {
+                        app.dispatch(IoEvent::ToggleSaveTrack(id.to_string()));
                     }
                 }
             }
@@ -28,7 +29,7 @@ mod tests {
 
     #[test]
     fn on_left_press() {
-        let mut app = App::new();
+        let mut app = App::default();
         app.set_current_route_state(Some(ActiveBlock::PlayBar), Some(ActiveBlock::PlayBar));
 
         handler(Key::Up, &mut app);

--- a/src/handlers/playlist.rs
+++ b/src/handlers/playlist.rs
@@ -3,6 +3,7 @@ use super::{
     common_key_events,
 };
 use crate::event::Key;
+use crate::network::IoEvent;
 
 pub fn handler(key: Key, app: &mut App) {
     match key {
@@ -70,20 +71,12 @@ pub fn handler(key: Key, app: &mut App) {
                     playlists.items.get(selected_playlist_index.to_owned())
                 {
                     let playlist_id = selected_playlist.id.to_owned();
-                    app.get_playlist_tracks(playlist_id);
+                    app.dispatch(IoEvent::GetPlaylistTracks(playlist_id, app.playlist_offset));
                 }
             };
         }
         Key::Char('D') => {
-            app.user_unfollow_playlists();
-            if let Some(spotify) = &app.spotify {
-                let playlists = spotify.current_user_playlists(app.large_search_limit, None);
-
-                match playlists {
-                    Ok(p) => app.playlists = Some(p),
-                    Err(e) => app.handle_error(e),
-                };
-            }
+            app.user_unfollow_playlist();
         }
         _ => {}
     }

--- a/src/handlers/recently_played.rs
+++ b/src/handlers/recently_played.rs
@@ -1,5 +1,5 @@
 use super::{super::app::App, common_key_events};
-use crate::{app::RecommendationsContext, event::Key};
+use crate::{app::RecommendationsContext, event::Key, network::IoEvent};
 
 pub fn handler(key: Key, app: &mut App) {
     match key {
@@ -48,7 +48,7 @@ pub fn handler(key: Key, app: &mut App) {
                     recently_played_result.items.get(app.recently_played.index)
                 {
                     if let Some(track_id) = &selected_track.track.id {
-                        app.toggle_save_track(track_id.clone());
+                        app.dispatch(IoEvent::ToggleSaveTrack(track_id.to_string()));
                     };
                 };
             };
@@ -61,7 +61,11 @@ pub fn handler(key: Key, app: &mut App) {
                     .map(|item| item.track.uri.to_owned())
                     .collect();
 
-                app.start_playback(None, Some(track_uris), Some(app.recently_played.index));
+                app.dispatch(IoEvent::StartPlayback(
+                    None,
+                    Some(track_uris),
+                    Some(app.recently_played.index),
+                ));
             };
         }
         Key::Char('r') => {
@@ -73,7 +77,7 @@ pub fn handler(key: Key, app: &mut App) {
                     if let Some(id) = &item.track.id {
                         app.recommendations_context = Some(RecommendationsContext::Song);
                         app.recommendations_seed = item.track.name.clone();
-                        app.get_recommendations_for_trackid(&id);
+                        app.get_recommendations_for_track_id(id.to_string());
                     }
                 }
             }
@@ -88,7 +92,7 @@ mod tests {
 
     #[test]
     fn on_left_press() {
-        let mut app = App::new();
+        let mut app = App::default();
         app.set_current_route_state(
             Some(ActiveBlock::AlbumTracks),
             Some(ActiveBlock::AlbumTracks),
@@ -102,7 +106,7 @@ mod tests {
 
     #[test]
     fn on_esc() {
-        let mut app = App::new();
+        let mut app = App::default();
 
         handler(Key::Esc, &mut app);
 

--- a/src/handlers/select_device.rs
+++ b/src/handlers/select_device.rs
@@ -3,6 +3,7 @@ use super::{
     common_key_events,
 };
 use crate::event::Key;
+use crate::network::IoEvent;
 
 pub fn handler(key: Key, app: &mut App) {
     match key {
@@ -71,16 +72,9 @@ pub fn handler(key: Key, app: &mut App) {
             };
         }
         Key::Enter => {
-            if let (Some(devices), Some(index)) = (&app.devices, app.selected_device_index) {
+            if let (Some(devices), Some(index)) = (app.devices.clone(), app.selected_device_index) {
                 if let Some(device) = &devices.devices.get(index) {
-                    match app.client_config.set_device_id(device.id.clone()) {
-                        Ok(()) => {
-                            app.pop_navigation_stack();
-                        }
-                        Err(e) => {
-                            app.handle_error(e);
-                        }
-                    };
+                    app.dispatch(IoEvent::SetDeviceIdInConfig(device.id.clone()));
                 }
             };
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod banner;
 mod config;
 mod event;
 mod handlers;
+mod network;
 mod redirect_uri;
 mod ui;
 mod user_config;
@@ -22,18 +23,21 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
+use network::{IoEvent, Network};
 use redirect_uri::redirect_uri_web_server;
-use rspotify::spotify::{
+use rspotify::{
     client::Spotify,
     oauth2::{SpotifyClientCredentials, SpotifyOAuth, TokenInfo},
-    util::{get_token, process_token, request_token},
+    util::{process_token, request_token},
 };
 use std::{
     cmp::{max, min},
     io::{self, stdout, Write},
     panic::{self, PanicInfo},
+    sync::Arc,
     time::{Duration, Instant},
 };
+use tokio::sync::Mutex;
 use tui::{
     backend::{Backend, CrosstermBackend},
     Terminal,
@@ -73,18 +77,18 @@ fn get_spotify(token_info: TokenInfo) -> (Spotify, Instant) {
     (spotify, token_expiry)
 }
 /// get token automatically with local webserver
-pub fn get_token_auto(spotify_oauth: &mut SpotifyOAuth, port: u16) -> Option<TokenInfo> {
-    match spotify_oauth.get_cached_token() {
+pub async fn get_token_auto(spotify_oauth: &mut SpotifyOAuth, port: u16) -> Option<TokenInfo> {
+    match spotify_oauth.get_cached_token().await {
         Some(token_info) => Some(token_info),
         None => match redirect_uri_web_server(spotify_oauth, port) {
-            Ok(mut url) => process_token(spotify_oauth, &mut url),
+            Ok(mut url) => process_token(spotify_oauth, &mut url).await,
             Err(()) => {
                 println!("Starting webserver failed. Continuing with manual authentication");
                 request_token(spotify_oauth);
                 println!("Enter the URL you were redirected to: ");
                 let mut input = String::new();
                 match io::stdin().read_line(&mut input) {
-                    Ok(_) => process_token(spotify_oauth, &mut input),
+                    Ok(_) => process_token(spotify_oauth, &mut input).await,
                     Err(_) => None,
                 }
             }
@@ -127,7 +131,8 @@ fn panic_hook(info: &PanicInfo<'_>) {
     }
 }
 
-fn main() -> Result<(), failure::Error> {
+#[tokio::main]
+async fn main() -> Result<(), failure::Error> {
     panic::set_hook(Box::new(|info| {
         panic_hook(info);
     }));
@@ -174,192 +179,179 @@ fn main() -> Result<(), failure::Error> {
         .scope(&SCOPES.join(" "))
         .build();
 
-    match get_token_auto(&mut oauth, client_config.get_port()) {
+    let config_port = client_config.get_port();
+    match get_token_auto(&mut oauth, config_port).await {
         Some(token_info) => {
-            // Terminal initialization
-            let mut stdout = stdout();
-            execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-            enable_raw_mode()?;
-
-            let backend = CrosstermBackend::new(stdout);
-            let mut terminal = Terminal::new(backend)?;
-            terminal.hide_cursor()?;
-
-            let events = event::Events::new(user_config.behavior.tick_rate_milliseconds);
+            let (sync_io_tx, sync_io_rx) = std::sync::mpsc::channel::<IoEvent>();
 
             // Initialise app state
-            let mut app = App::new();
+            let app = Arc::new(Mutex::new(App::new(sync_io_tx, user_config.clone())));
+            let (spotify, token_expiry) = get_spotify(token_info);
 
-            let (mut spotify, mut token_expiry) = get_spotify(token_info);
+            let cloned_app = Arc::clone(&app);
+            std::thread::spawn(move || {
+                let mut network = Network::new(oauth, spotify, token_expiry, client_config, &app);
+                start_tokio(sync_io_rx, &mut network);
+            });
 
-            app.client_config = client_config;
-            app.user_config = user_config;
-
-            app.spotify = Some(spotify);
-
-            app.clipboard_context = clipboard::ClipboardProvider::new().ok();
-
-            app.help_docs_size = ui::help::get_help_docs().len() as u32;
-
-            // Now that spotify is ready, check if the user has already selected a device_id to
-            // play music on, if not send them to the device selection view
-            if app.client_config.device_id.is_none() {
-                app.handle_get_devices();
-            }
-
-            let mut is_first_render = true;
-
-            loop {
-                // Get the size of the screen on each loop to account for resize event
-                if let Ok(size) = terminal.backend().size() {
-                    // Reset the help menu is the terminal was resized
-                    if app.size != size {
-                        app.help_menu_max_lines = 0;
-                        app.help_menu_offset = 0;
-                        app.help_menu_page = 0;
-                    }
-
-                    app.size = size;
-
-                    // Based on the size of the terminal, adjust the search limit.
-                    let potential_limit = max((app.size.height as i32) - 13, 0) as u32;
-                    let max_limit = min(potential_limit, 50);
-                    app.large_search_limit = min((f32::from(size.height) / 1.4) as u32, max_limit);
-                    app.small_search_limit =
-                        min((f32::from(size.height) / 2.85) as u32, max_limit / 2);
-
-                    // Based on the size of the terminal, adjust how many lines are
-                    // dislayed in the help menu
-                    if app.size.height > 8 {
-                        app.help_menu_max_lines = (app.size.height as u32) - 8;
-                    } else {
-                        app.help_menu_max_lines = 0;
-                    }
-                };
-
-                let current_route = app.get_current_route();
-                terminal.draw(|mut f| match current_route.active_block {
-                    ActiveBlock::HelpMenu => {
-                        ui::draw_help_menu(&mut f, &app);
-                    }
-                    ActiveBlock::Error => {
-                        ui::draw_error_screen(&mut f, &app);
-                    }
-                    ActiveBlock::SelectDevice => {
-                        ui::draw_device_list(&mut f, &app);
-                    }
-                    ActiveBlock::Analysis => {
-                        ui::audio_analysis::draw(&mut f, &app);
-                    }
-                    _ => {
-                        ui::draw_main_layout(&mut f, &app);
-                    }
-                })?;
-
-                if current_route.active_block == ActiveBlock::Input {
-                    match terminal.show_cursor() {
-                        Ok(_r) => {}
-                        Err(_e) => {}
-                    };
-                } else {
-                    match terminal.hide_cursor() {
-                        Ok(_r) => {}
-                        Err(_e) => {}
-                    };
-                }
-
-                let cursor_offset = if app.size.height > ui::util::SMALL_TERMINAL_HEIGHT {
-                    2
-                } else {
-                    1
-                };
-
-                // Put the cursor back inside the input box
-                terminal.backend_mut().execute(MoveTo(
-                    cursor_offset + app.input_cursor_position,
-                    cursor_offset,
-                ))?;
-
-                if Instant::now() > token_expiry {
-                    // refresh token
-                    if let Some(new_token_info) = get_token(&mut oauth) {
-                        let (new_spotify, new_token_expiry) = get_spotify(new_token_info);
-                        spotify = new_spotify;
-                        token_expiry = new_token_expiry;
-                        app.spotify = Some(spotify);
-                    } else {
-                        println!("\nFailed to refresh authentication token");
-                        close_application()?;
-                        break;
-                    }
-                }
-
-                match events.next()? {
-                    event::Event::Input(key) => {
-                        if key == Key::Ctrl('c') {
-                            close_application()?;
-                            break;
-                        }
-
-                        let current_active_block = app.get_current_route().active_block;
-
-                        // To avoid swallowing the global key presses `q` and `-` make a special
-                        // case for the input handler
-                        if current_active_block == ActiveBlock::Input {
-                            handlers::input_handler(key, &mut app);
-                        } else if key == app.user_config.keys.back {
-                            if app.get_current_route().active_block != ActiveBlock::Input {
-                                // Go back through navigation stack when not in search input mode and exit the app if there are no more places to back to
-
-                                let pop_result = match app.pop_navigation_stack() {
-                                    Some(ref x) if x.id == RouteId::Search => {
-                                        app.pop_navigation_stack()
-                                    }
-                                    Some(x) => Some(x),
-                                    None => None,
-                                };
-                                if pop_result.is_none() {
-                                    close_application()?;
-                                    break; // Exit application
-                                }
-                            }
-                        } else {
-                            handlers::handle_app(key, &mut app);
-                        }
-                    }
-                    event::Event::Tick => {
-                        app.update_on_tick();
-                    }
-                }
-
-                // Delay spotify request until first render, will have the effect of improving
-                // startup speed
-                if is_first_render {
-                    if let Some(spotify) = &app.spotify {
-                        let playlists =
-                            spotify.current_user_playlists(app.large_search_limit, None);
-
-                        match playlists {
-                            Ok(p) => {
-                                app.playlists = Some(p);
-                                // Select the first playlist
-                                app.selected_playlist_index = Some(0);
-                            }
-                            Err(e) => {
-                                app.handle_error(e);
-                            }
-                        };
-
-                        app.get_user();
-                    }
-
-                    app.get_current_playback();
-                    is_first_render = false;
-                }
-            }
+            // The UI must run in the "main" thread
+            start_ui(user_config, &cloned_app, token_expiry).await?;
         }
         None => println!("\nSpotify auth failed"),
     }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn start_tokio<'a>(io_rx: std::sync::mpsc::Receiver<IoEvent>, network: &mut Network) {
+    while let Ok(io_event) = io_rx.recv() {
+        network.handle_network_event(io_event).await;
+    }
+}
+
+async fn start_ui(
+    user_config: UserConfig,
+    app: &Arc<Mutex<App>>,
+    token_expiry: Instant,
+) -> Result<(), failure::Error> {
+    // Terminal initialization
+    let mut stdout = stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    enable_raw_mode()?;
+
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    terminal.hide_cursor()?;
+
+    let events = event::Events::new(user_config.behavior.tick_rate_milliseconds);
+
+    // play music on, if not send them to the device selection view
+
+    let mut is_first_render = true;
+
+    loop {
+        let mut app = app.lock().await;
+        // Get the size of the screen on each loop to account for resize event
+        if let Ok(size) = terminal.backend().size() {
+            // Reset the help menu is the terminal was resized
+            if is_first_render || app.size != size {
+                app.help_menu_max_lines = 0;
+                app.help_menu_offset = 0;
+                app.help_menu_page = 0;
+
+                app.size = size;
+
+                // Based on the size of the terminal, adjust the search limit.
+                let potential_limit = max((app.size.height as i32) - 13, 0) as u32;
+                let max_limit = min(potential_limit, 50);
+                let large_search_limit = min((f32::from(size.height) / 1.4) as u32, max_limit);
+                let small_search_limit = min((f32::from(size.height) / 2.85) as u32, max_limit / 2);
+
+                app.dispatch(IoEvent::UpdateSearchLimits(
+                    large_search_limit,
+                    small_search_limit,
+                ));
+
+                // Based on the size of the terminal, adjust how many lines are
+                // dislayed in the help menu
+                if app.size.height > 8 {
+                    app.help_menu_max_lines = (app.size.height as u32) - 8;
+                } else {
+                    app.help_menu_max_lines = 0;
+                }
+            }
+        };
+
+        let current_route = app.get_current_route();
+        terminal.draw(|mut f| match current_route.active_block {
+            ActiveBlock::HelpMenu => {
+                ui::draw_help_menu(&mut f, &app);
+            }
+            ActiveBlock::Error => {
+                ui::draw_error_screen(&mut f, &app);
+            }
+            ActiveBlock::SelectDevice => {
+                ui::draw_device_list(&mut f, &app);
+            }
+            ActiveBlock::Analysis => {
+                ui::audio_analysis::draw(&mut f, &app);
+            }
+            _ => {
+                ui::draw_main_layout(&mut f, &app);
+            }
+        })?;
+
+        if current_route.active_block == ActiveBlock::Input {
+            terminal.show_cursor()?;
+        } else {
+            terminal.hide_cursor()?;
+        }
+
+        let cursor_offset = if app.size.height > ui::util::SMALL_TERMINAL_HEIGHT {
+            2
+        } else {
+            1
+        };
+
+        // Put the cursor back inside the input box
+        terminal.backend_mut().execute(MoveTo(
+            cursor_offset + app.input_cursor_position,
+            cursor_offset,
+        ))?;
+
+        // Handle authentication refresh
+        if Instant::now() > token_expiry {
+            app.dispatch(IoEvent::RefreshAuthentication);
+        }
+
+        match events.next()? {
+            event::Event::Input(key) => {
+                if key == Key::Ctrl('c') {
+                    break;
+                }
+
+                let current_active_block = app.get_current_route().active_block;
+
+                // To avoid swallowing the global key presses `q` and `-` make a special
+                // case for the input handler
+                if current_active_block == ActiveBlock::Input {
+                    handlers::input_handler(key, &mut app);
+                } else if key == app.user_config.keys.back {
+                    if app.get_current_route().active_block != ActiveBlock::Input {
+                        // Go back through navigation stack when not in search input mode and exit the app if there are no more places to back to
+
+                        let pop_result = match app.pop_navigation_stack() {
+                            Some(ref x) if x.id == RouteId::Search => app.pop_navigation_stack(),
+                            Some(x) => Some(x),
+                            None => None,
+                        };
+                        if pop_result.is_none() {
+                            break; // Exit application
+                        }
+                    }
+                } else {
+                    handlers::handle_app(key, &mut app);
+                }
+            }
+            event::Event::Tick => {
+                app.update_on_tick();
+            }
+        }
+
+        // Delay spotify request until first render, will have the effect of improving
+        // startup speed
+        if is_first_render {
+            app.dispatch(IoEvent::GetPlaylists);
+            app.dispatch(IoEvent::GetUser);
+            app.dispatch(IoEvent::GetCurrentPlayback);
+
+            app.help_docs_size = ui::help::get_help_docs().len() as u32;
+
+            is_first_render = false;
+        }
+    }
+    close_application()?;
 
     Ok(())
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,0 +1,1099 @@
+use crate::app::{
+    ActiveBlock, AlbumTableContext, App, Artist, ArtistBlock, RouteId, SelectedAlbum,
+    SelectedFullAlbum, TrackTableContext,
+};
+use crate::config::ClientConfig;
+use rspotify::{
+    client::Spotify,
+    model::{
+        album::SimplifiedAlbum,
+        offset::for_position,
+        page::Page,
+        playlist::{PlaylistTrack, SimplifiedPlaylist},
+        recommend::Recommendations,
+        track::FullTrack,
+    },
+    oauth2::{SpotifyClientCredentials, SpotifyOAuth, TokenInfo},
+    senum::{Country, RepeatState},
+    util::get_token,
+};
+use serde_json::{map::Map, Value};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tokio::sync::Mutex;
+use tokio::try_join;
+
+#[derive(Debug)]
+pub enum IoEvent {
+    GetCurrentPlayback,
+    RefreshAuthentication,
+    GetPlaylists,
+    GetDevices,
+    GetSearchResults(String, Option<Country>),
+    SetTracksToTable(Vec<FullTrack>),
+    GetMadeForYouPlaylistTracks(String, u32),
+    GetPlaylistTracks(String, u32),
+    GetCurrentSavedTracks(Option<u32>, bool),
+    StartPlayback(Option<String>, Option<Vec<String>>, Option<usize>),
+    UpdateSearchLimits(u32, u32),
+    Seek(u32),
+    NextTrack,
+    PreviousTrack,
+    Shuffle(bool),
+    Repeat(RepeatState),
+    PausePlayback,
+    ChangeVolume(u8),
+    GetArtist(String, String, Option<Country>),
+    GetAlbumTracks(Box<SimplifiedAlbum>),
+    GetRecommendationsForSeed(
+        Option<Vec<String>>,
+        Option<Vec<String>>,
+        Box<Option<FullTrack>>,
+        Option<Country>,
+    ),
+    GetCurrentUserSavedAlbums(Option<u32>),
+    CurrentUserSavedAlbumDelete(String),
+    CurrentUserSavedAlbumAdd(String),
+    UserUnfollowArtists(Vec<String>),
+    UserFollowArtists(Vec<String>),
+    UserFollowPlaylist(String, String, Option<bool>),
+    UserUnfollowPlaylist(String, String),
+    MadeForYouSearchAndAdd(String, Option<Country>),
+    GetAudioAnalysis(String),
+    GetUser,
+    ToggleSaveTrack(String),
+    GetRecommendationsForTrackId(String, Option<Country>),
+    GetRecentlyPlayed,
+    GetFollowedArtists(Option<String>),
+    GetAlbum(String),
+    SetDeviceIdInConfig(String),
+    CurrentUserSavedTracksContains(Vec<String>),
+}
+
+pub fn get_spotify(token_info: TokenInfo) -> (Spotify, Instant) {
+    let token_expiry = Instant::now()
+        + Duration::from_secs(token_info.expires_in.into())
+        // Set 10 seconds early
+        - Duration::from_secs(10);
+
+    let client_credential = SpotifyClientCredentials::default()
+        .token_info(token_info)
+        .build();
+
+    let spotify = Spotify::default()
+        .client_credentials_manager(client_credential)
+        .build();
+
+    (spotify, token_expiry)
+}
+
+#[derive(Clone)]
+pub struct Network<'a> {
+    oauth: SpotifyOAuth,
+    spotify: Spotify,
+    spotify_token_expiry: Instant,
+    large_search_limit: u32,
+    small_search_limit: u32,
+    client_config: ClientConfig,
+    app: &'a Arc<Mutex<App>>,
+}
+
+impl<'a> Network<'a> {
+    pub fn new(
+        oauth: SpotifyOAuth,
+        spotify: Spotify,
+        spotify_token_expiry: Instant,
+        client_config: ClientConfig,
+        app: &'a Arc<Mutex<App>>,
+    ) -> Self {
+        Network {
+            oauth,
+            spotify,
+            spotify_token_expiry,
+            large_search_limit: 20,
+            small_search_limit: 4,
+            client_config,
+            app,
+        }
+    }
+
+    #[allow(clippy::cognitive_complexity)]
+    pub async fn handle_network_event(&mut self, io_event: IoEvent) {
+        match io_event {
+            IoEvent::RefreshAuthentication => {
+                self.refresh_authentication().await;
+            }
+            IoEvent::GetPlaylists => {
+                self.get_current_user_playlists().await;
+            }
+            IoEvent::GetUser => {
+                self.get_user().await;
+            }
+            IoEvent::GetDevices => {
+                self.get_devices().await;
+            }
+            IoEvent::GetCurrentPlayback => {
+                self.get_current_playback().await;
+            }
+            IoEvent::SetTracksToTable(full_tracks) => {
+                self.set_tracks_to_table(full_tracks).await;
+            }
+            IoEvent::GetSearchResults(search_term, country) => {
+                self.get_search_results(search_term, country).await;
+            }
+            IoEvent::GetMadeForYouPlaylistTracks(playlist_id, made_for_you_offset) => {
+                self.get_made_for_you_playlist_tracks(playlist_id, made_for_you_offset)
+                    .await;
+            }
+            IoEvent::GetPlaylistTracks(playlist_id, playlist_offset) => {
+                self.get_playlist_tracks(playlist_id, playlist_offset).await;
+            }
+            IoEvent::GetCurrentSavedTracks(offset, should_navigate) => {
+                self.get_current_user_saved_tracks(offset, should_navigate)
+                    .await;
+            }
+            IoEvent::StartPlayback(context_uri, uris, offset) => {
+                self.start_playback(context_uri, uris, offset).await;
+            }
+            IoEvent::UpdateSearchLimits(large_search_limit, small_search_limit) => {
+                self.large_search_limit = large_search_limit;
+                self.small_search_limit = small_search_limit;
+            }
+            IoEvent::Seek(position_ms) => {
+                self.seek(position_ms).await;
+            }
+            IoEvent::NextTrack => {
+                self.next_track().await;
+            }
+            IoEvent::PreviousTrack => {
+                self.previous_track().await;
+            }
+            IoEvent::Repeat(repeat_state) => {
+                self.repeat(repeat_state).await;
+            }
+            IoEvent::PausePlayback => {
+                self.pause_playback().await;
+            }
+            IoEvent::ChangeVolume(volume) => {
+                self.change_volume(volume).await;
+            }
+            IoEvent::GetArtist(artist_id, input_artist_name, country) => {
+                self.get_artist(artist_id, input_artist_name, country).await;
+            }
+            IoEvent::GetAlbumTracks(album) => {
+                self.get_album_tracks(album).await;
+            }
+            IoEvent::GetRecommendationsForSeed(seed_artists, seed_tracks, first_track, country) => {
+                self.get_recommendations_for_seed(seed_artists, seed_tracks, first_track, country)
+                    .await;
+            }
+            IoEvent::GetCurrentUserSavedAlbums(offset) => {
+                self.get_current_user_saved_albums(offset).await;
+            }
+            IoEvent::CurrentUserSavedAlbumDelete(album_id) => {
+                self.current_user_saved_album_delete(album_id).await;
+            }
+            IoEvent::CurrentUserSavedAlbumAdd(album_id) => {
+                self.current_user_saved_album_add(album_id).await;
+            }
+            IoEvent::UserUnfollowArtists(artist_ids) => {
+                self.user_unfollow_artists(artist_ids).await;
+            }
+            IoEvent::UserFollowArtists(artist_ids) => {
+                self.user_follow_artists(artist_ids).await;
+            }
+            IoEvent::UserFollowPlaylist(playlist_owner_id, playlist_id, is_public) => {
+                self.user_follow_playlist(playlist_owner_id, playlist_id, is_public)
+                    .await;
+            }
+            IoEvent::UserUnfollowPlaylist(user_id, playlist_id) => {
+                self.user_unfollow_playlist(user_id, playlist_id).await;
+            }
+            IoEvent::MadeForYouSearchAndAdd(search_term, country) => {
+                self.made_for_you_search_and_add(search_term, country).await;
+            }
+            IoEvent::GetAudioAnalysis(uri) => {
+                self.get_audio_analysis(uri).await;
+            }
+            IoEvent::ToggleSaveTrack(track_id) => {
+                self.toggle_save_track(track_id).await;
+            }
+            IoEvent::GetRecommendationsForTrackId(track_id, country) => {
+                self.get_recommendations_for_track_id(track_id, country)
+                    .await;
+            }
+            IoEvent::GetRecentlyPlayed => {
+                self.get_recently_played().await;
+            }
+            IoEvent::GetFollowedArtists(after) => {
+                self.get_followed_artists(after).await;
+            }
+            IoEvent::GetAlbum(album_id) => {
+                self.get_album(album_id).await;
+            }
+            IoEvent::SetDeviceIdInConfig(device_id) => {
+                self.set_device_id_in_config(device_id).await;
+            }
+            IoEvent::Shuffle(shuffle_state) => {
+                self.shuffle(shuffle_state).await;
+            }
+            IoEvent::CurrentUserSavedTracksContains(track_ids) => {
+                self.current_user_saved_tracks_contains(track_ids).await;
+            }
+        };
+
+        let mut app = self.app.lock().await;
+        app.is_loading = false;
+    }
+
+    async fn handle_error(&mut self, e: failure::Error) {
+        let mut app = self.app.lock().await;
+        app.handle_error(e);
+    }
+
+    async fn get_user(&mut self) {
+        match self.spotify.current_user().await {
+            Ok(user) => {
+                let mut app = self.app.lock().await;
+                app.user = Some(user);
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        }
+    }
+
+    async fn get_devices(&mut self) {
+        if let Ok(result) = self.spotify.device().await {
+            let mut app = self.app.lock().await;
+            app.push_navigation_stack(RouteId::SelectedDevice, ActiveBlock::SelectDevice);
+            if !result.devices.is_empty() {
+                app.devices = Some(result);
+                // Select the first device in the list
+                app.selected_device_index = Some(0);
+            }
+        }
+    }
+
+    async fn get_current_playback(&mut self) {
+        let context = self.spotify.current_playback(None).await;
+        if let Ok(ctx) = context {
+            if let Some(c) = ctx {
+                let mut app = self.app.lock().await;
+                app.current_playback_context = Some(c.clone());
+                app.instant_since_last_current_playback_poll = Instant::now();
+
+                if let Some(track_id) = &c.item.and_then(|track| track.id) {
+                    app.dispatch(IoEvent::CurrentUserSavedTracksContains(vec![
+                        track_id.to_owned()
+                    ]));
+                };
+            };
+        }
+        let mut app = self.app.lock().await;
+        app.is_fetching_current_playback = false;
+    }
+
+    async fn current_user_saved_tracks_contains(&mut self, ids: Vec<String>) {
+        match self.spotify.current_user_saved_tracks_contains(&ids).await {
+            Ok(is_saved_vec) => {
+                let mut app = self.app.lock().await;
+                for (i, id) in ids.iter().enumerate() {
+                    if let Some(is_liked) = is_saved_vec.get(i) {
+                        if *is_liked {
+                            app.liked_song_ids_set.insert(id.to_string());
+                        } else {
+                            // The song is not liked, so check if it should be removed
+                            if app.liked_song_ids_set.contains(id) {
+                                app.liked_song_ids_set.remove(id);
+                            }
+                        }
+                    };
+                }
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        }
+    }
+
+    async fn get_playlist_tracks(&mut self, playlist_id: String, playlist_offset: u32) {
+        if let Ok(playlist_tracks) = self
+            .spotify
+            .user_playlist_tracks(
+                "spotify",
+                &playlist_id,
+                None,
+                Some(self.large_search_limit),
+                Some(playlist_offset),
+                None,
+            )
+            .await
+        {
+            self.set_playlist_tracks_to_table(&playlist_tracks).await;
+
+            let mut app = self.app.lock().await;
+            app.playlist_tracks = Some(playlist_tracks);
+            if app.get_current_route().id != RouteId::TrackTable {
+                app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+            };
+        };
+    }
+
+    async fn set_playlist_tracks_to_table(&mut self, playlist_track_page: &Page<PlaylistTrack>) {
+        self.set_tracks_to_table(
+            playlist_track_page
+                .items
+                .clone()
+                .into_iter()
+                .map(|item| item.track.unwrap())
+                .collect::<Vec<FullTrack>>(),
+        )
+        .await;
+    }
+
+    async fn set_tracks_to_table(&mut self, tracks: Vec<FullTrack>) {
+        let mut app = self.app.lock().await;
+        app.track_table.tracks = tracks.clone();
+
+        // Send this event round (don't block here)
+        app.dispatch(IoEvent::CurrentUserSavedTracksContains(
+            tracks
+                .into_iter()
+                .filter_map(|item| item.id)
+                .collect::<Vec<String>>(),
+        ));
+    }
+
+    async fn get_made_for_you_playlist_tracks(
+        &mut self,
+        playlist_id: String,
+        made_for_you_offset: u32,
+    ) {
+        if let Ok(made_for_you_tracks) = self
+            .spotify
+            .user_playlist_tracks(
+                "spotify",
+                &playlist_id,
+                None,
+                Some(self.large_search_limit),
+                Some(made_for_you_offset),
+                None,
+            )
+            .await
+        {
+            self.set_playlist_tracks_to_table(&made_for_you_tracks)
+                .await;
+
+            let mut app = self.app.lock().await;
+            app.made_for_you_tracks = Some(made_for_you_tracks);
+            if app.get_current_route().id != RouteId::TrackTable {
+                app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+            }
+        }
+    }
+
+    async fn get_search_results(&mut self, search_term: String, country: Option<Country>) {
+        let search_track =
+            self.spotify
+                .search_track(&search_term, self.small_search_limit, 0, country);
+
+        let search_artist =
+            self.spotify
+                .search_artist(&search_term, self.small_search_limit, 0, country);
+
+        let search_album =
+            self.spotify
+                .search_album(&search_term, self.small_search_limit, 0, country);
+
+        let search_playlist =
+            self.spotify
+                .search_playlist(&search_term, self.small_search_limit, 0, country);
+
+        // Run the futures concurrently
+        match try_join!(search_track, search_artist, search_album, search_playlist) {
+            Ok((track_results, artist_results, album_results, playlist_results)) => {
+                let mut app = self.app.lock().await;
+                app.search_results.tracks = Some(track_results);
+                app.search_results.artists = Some(artist_results);
+                app.search_results.albums = Some(album_results);
+                app.search_results.playlists = Some(playlist_results);
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        };
+    }
+
+    async fn get_current_user_saved_tracks(&mut self, offset: Option<u32>, should_navigate: bool) {
+        match self
+            .spotify
+            .current_user_saved_tracks(self.large_search_limit, offset)
+            .await
+        {
+            Ok(saved_tracks) => {
+                let mut app = self.app.lock().await;
+                app.track_table.tracks = saved_tracks
+                    .items
+                    .clone()
+                    .into_iter()
+                    .map(|item| item.track)
+                    .collect::<Vec<FullTrack>>();
+
+                saved_tracks.items.iter().for_each(|item| {
+                    if let Some(track_id) = &item.track.id {
+                        app.liked_song_ids_set.insert(track_id.to_string());
+                    }
+                });
+
+                app.library.saved_tracks.add_pages(saved_tracks);
+                app.track_table.context = Some(TrackTableContext::SavedTracks);
+
+                if should_navigate {
+                    app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
+                }
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        }
+    }
+
+    async fn start_playback(
+        &mut self,
+        context_uri: Option<String>,
+        uris: Option<Vec<String>>,
+        offset: Option<usize>,
+    ) {
+        let (uris, context_uri) = if context_uri.is_some() {
+            (None, context_uri)
+        } else if uris.is_some() {
+            (uris, None)
+        } else {
+            (None, None)
+        };
+
+        let offset = offset.and_then(|o| for_position(o as u32));
+
+        let result = match &self.client_config.device_id {
+            Some(device_id) => {
+                self.spotify
+                    .start_playback(
+                        Some(device_id.to_string()),
+                        context_uri.clone(),
+                        uris.clone(),
+                        offset.clone(),
+                        None,
+                    )
+                    .await
+            }
+            None => Err(failure::err_msg("No device_id selected")),
+        };
+
+        match result {
+            Ok(()) => {
+                self.get_current_playback().await;
+
+                let mut app = self.app.lock().await;
+                app.song_progress_ms = 0;
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        }
+    }
+
+    async fn seek(&mut self, position_ms: u32) {
+        if let Some(device_id) = &self.client_config.device_id {
+            match self
+                .spotify
+                .seek_track(position_ms, Some(device_id.to_string()))
+                .await
+            {
+                Ok(()) => {
+                    self.get_current_playback().await;
+                }
+                Err(e) => {
+                    self.handle_error(e).await;
+                }
+            };
+        }
+    }
+
+    async fn next_track(&mut self) {
+        match self
+            .spotify
+            .next_track(self.client_config.device_id.clone())
+            .await
+        {
+            Ok(()) => {
+                self.get_current_playback().await;
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        };
+    }
+
+    async fn previous_track(&mut self) {
+        match self
+            .spotify
+            .previous_track(self.client_config.device_id.clone())
+            .await
+        {
+            Ok(()) => {
+                self.get_current_playback().await;
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        };
+    }
+
+    async fn shuffle(&mut self, shuffle_state: bool) {
+        match self
+            .spotify
+            .shuffle(!shuffle_state, self.client_config.device_id.clone())
+            .await
+        {
+            Ok(()) => {
+                // Update the UI eagerly (otherwise the UI will wait until the next 5 second interval
+                // due to polling playback context)
+                let mut app = self.app.lock().await;
+                if let Some(current_playback_context) = &mut app.current_playback_context {
+                    current_playback_context.shuffle_state = !shuffle_state;
+                };
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        };
+    }
+
+    async fn repeat(&mut self, repeat_state: RepeatState) {
+        let next_repeat_state = match repeat_state {
+            RepeatState::Off => RepeatState::Context,
+            RepeatState::Context => RepeatState::Track,
+            RepeatState::Track => RepeatState::Off,
+        };
+        match self
+            .spotify
+            .repeat(next_repeat_state, self.client_config.device_id.clone())
+            .await
+        {
+            Ok(()) => {
+                let mut app = self.app.lock().await;
+                if let Some(current_playback_context) = &mut app.current_playback_context {
+                    current_playback_context.repeat_state = next_repeat_state;
+                };
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        };
+    }
+
+    async fn pause_playback(&mut self) {
+        match self
+            .spotify
+            .pause_playback(self.client_config.device_id.clone())
+            .await
+        {
+            Ok(()) => {
+                self.get_current_playback().await;
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        };
+    }
+
+    async fn change_volume(&mut self, volume_percent: u8) {
+        match self
+            .spotify
+            .volume(volume_percent, self.client_config.device_id.clone())
+            .await
+        {
+            Ok(()) => {
+                let mut app = self.app.lock().await;
+                if let Some(current_playback_context) = &mut app.current_playback_context {
+                    current_playback_context.device.volume_percent = volume_percent.into();
+                };
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        };
+    }
+
+    async fn get_artist(
+        &mut self,
+        artist_id: String,
+        input_artist_name: String,
+        country: Option<Country>,
+    ) {
+        let albums = self.spotify.artist_albums(
+            &artist_id,
+            None,
+            country,
+            Some(self.large_search_limit),
+            Some(0),
+        );
+        let mut artist_name = String::from("");
+        if input_artist_name == "" {
+            if let Ok(full_artist) = self.spotify.artist(&artist_id).await {
+                artist_name = full_artist.name;
+            }
+        } else {
+            artist_name = input_artist_name;
+        }
+        let top_tracks = self.spotify.artist_top_tracks(&artist_id, country);
+        let related_artist = self.spotify.artist_related_artists(&artist_id);
+
+        if let Ok((albums, top_tracks, related_artist)) =
+            try_join!(albums, top_tracks, related_artist)
+        {
+            let mut app = self.app.lock().await;
+            app.artist = Some(Artist {
+                artist_name,
+                albums,
+                related_artists: related_artist.artists,
+                top_tracks: top_tracks.tracks,
+                selected_album_index: 0,
+                selected_related_artist_index: 0,
+                selected_top_track_index: 0,
+                artist_hovered_block: ArtistBlock::TopTracks,
+                artist_selected_block: ArtistBlock::Empty,
+            });
+        }
+    }
+
+    async fn get_album_tracks(&mut self, album: Box<SimplifiedAlbum>) {
+        if let Some(album_id) = &album.id {
+            match self
+                .spotify
+                .album_track(&album_id.clone(), self.large_search_limit, 0)
+                .await
+            {
+                Ok(tracks) => {
+                    let track_ids = tracks
+                        .items
+                        .iter()
+                        .filter_map(|item| item.id.clone())
+                        .collect::<Vec<String>>();
+
+                    let mut app = self.app.lock().await;
+                    app.selected_album_simplified = Some(SelectedAlbum {
+                        album: *album,
+                        tracks,
+                        selected_index: 0,
+                    });
+
+                    app.album_table_context = AlbumTableContext::Simplified;
+                    app.push_navigation_stack(RouteId::AlbumTracks, ActiveBlock::AlbumTracks);
+                    app.dispatch(IoEvent::CurrentUserSavedTracksContains(track_ids));
+                }
+                Err(e) => {
+                    self.handle_error(e).await;
+                }
+            }
+        }
+    }
+
+    async fn get_recommendations_for_seed(
+        &mut self,
+        seed_artists: Option<Vec<String>>,
+        seed_tracks: Option<Vec<String>>,
+        first_track: Box<Option<FullTrack>>,
+        country: Option<Country>,
+    ) {
+        let empty_payload: Map<String, Value> = Map::new();
+
+        match self
+            .spotify
+            .recommendations(
+                seed_artists,            // artists
+                None,                    // genres
+                seed_tracks,             // tracks
+                self.large_search_limit, // adjust playlist to screen size
+                country,                 // country
+                &empty_payload,          // payload
+            )
+            .await
+        {
+            Ok(result) => {
+                if let Some(mut recommended_tracks) = self.extract_recommended_tracks(&result).await
+                {
+                    //custom first track
+                    if let Some(track) = *first_track {
+                        recommended_tracks.insert(0, track);
+                    }
+
+                    let track_ids = recommended_tracks
+                        .iter()
+                        .map(|x| x.uri.clone())
+                        .collect::<Vec<String>>();
+
+                    self.set_tracks_to_table(recommended_tracks.clone()).await;
+
+                    let mut app = self.app.lock().await;
+                    app.recommended_tracks = recommended_tracks;
+                    app.track_table.context = Some(TrackTableContext::RecommendedTracks);
+
+                    if app.get_current_route().id != RouteId::Recommendations {
+                        app.push_navigation_stack(
+                            RouteId::Recommendations,
+                            ActiveBlock::TrackTable,
+                        );
+                    };
+
+                    app.dispatch(IoEvent::StartPlayback(None, Some(track_ids), Some(0)));
+                }
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        }
+    }
+
+    async fn extract_recommended_tracks(
+        &mut self,
+        recommendations: &Recommendations,
+    ) -> Option<Vec<FullTrack>> {
+        let tracks = recommendations
+            .clone()
+            .tracks
+            .into_iter()
+            .map(|item| item.uri)
+            .collect::<Vec<String>>();
+        if let Ok(result) = self
+            .spotify
+            .tracks(tracks.iter().map(|x| &x[..]).collect::<Vec<&str>>(), None)
+            .await
+        {
+            return Some(result.tracks);
+        }
+
+        None
+    }
+
+    async fn get_recommendations_for_track_id(&mut self, id: String, country: Option<Country>) {
+        if let Ok(track) = self.spotify.track(&id).await {
+            let track_id_list: Option<Vec<String>> = match &track.id {
+                Some(id) => Some(vec![id.to_string()]),
+                None => None,
+            };
+            self.get_recommendations_for_seed(None, track_id_list, Box::new(Some(track)), country)
+                .await;
+        }
+    }
+
+    async fn toggle_save_track(&mut self, track_id: String) {
+        match self
+            .spotify
+            .current_user_saved_tracks_contains(&[track_id.clone()])
+            .await
+        {
+            Ok(saved) => {
+                if saved.first() == Some(&true) {
+                    match self
+                        .spotify
+                        .current_user_saved_tracks_delete(&[track_id.clone()])
+                        .await
+                    {
+                        Ok(()) => {
+                            let mut app = self.app.lock().await;
+                            app.liked_song_ids_set.remove(&track_id);
+                        }
+                        Err(e) => {
+                            self.handle_error(e).await;
+                        }
+                    }
+                } else {
+                    match self
+                        .spotify
+                        .current_user_saved_tracks_add(&[track_id.clone()])
+                        .await
+                    {
+                        Ok(()) => {
+                            // TODO: This should ideally use the same logic as `self.current_user_saved_tracks_contains`
+                            let mut app = self.app.lock().await;
+                            app.liked_song_ids_set.insert(track_id);
+                        }
+                        Err(e) => {
+                            self.handle_error(e).await;
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        };
+    }
+
+    async fn get_followed_artists(&mut self, after: Option<String>) {
+        match self
+            .spotify
+            .current_user_followed_artists(self.large_search_limit, after)
+            .await
+        {
+            Ok(saved_artists) => {
+                let mut app = self.app.lock().await;
+                app.artists = saved_artists.artists.items.to_owned();
+                app.library.saved_artists.add_pages(saved_artists.artists);
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        };
+    }
+
+    async fn get_current_user_saved_albums(&mut self, offset: Option<u32>) {
+        match self
+            .spotify
+            .current_user_saved_albums(self.large_search_limit, offset)
+            .await
+        {
+            Ok(saved_albums) => {
+                // not to show a blank page
+                if !saved_albums.items.is_empty() {
+                    let mut app = self.app.lock().await;
+                    app.library.saved_albums.add_pages(saved_albums);
+                }
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        };
+    }
+
+    pub async fn current_user_saved_album_delete(&mut self, album_id: String) {
+        match self
+            .spotify
+            .current_user_saved_albums_delete(&[album_id.to_owned()])
+            .await
+        {
+            Ok(_) => {
+                self.get_current_user_saved_albums(None).await;
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        };
+    }
+
+    async fn current_user_saved_album_add(&mut self, artist_id: String) {
+        if let Err(e) = self
+            .spotify
+            .current_user_saved_albums_add(&[artist_id.to_owned()])
+            .await
+        {
+            self.handle_error(e).await;
+        };
+    }
+
+    async fn user_unfollow_artists(&mut self, artist_ids: Vec<String>) {
+        match self.spotify.user_unfollow_artists(&artist_ids).await {
+            Ok(_) => {
+                self.get_followed_artists(None).await;
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        }
+    }
+
+    async fn user_follow_artists(&mut self, artist_ids: Vec<String>) {
+        match self.spotify.user_follow_artists(&artist_ids).await {
+            Ok(_) => {
+                self.get_followed_artists(None).await;
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        }
+    }
+
+    async fn user_follow_playlist(
+        &mut self,
+        playlist_owner_id: String,
+        playlist_id: String,
+        is_public: Option<bool>,
+    ) {
+        match self
+            .spotify
+            .user_playlist_follow_playlist(&playlist_owner_id, &playlist_id, is_public)
+            .await
+        {
+            Ok(_) => {
+                self.get_current_user_playlists().await;
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        }
+    }
+
+    async fn user_unfollow_playlist(&mut self, user_id: String, playlist_id: String) {
+        match self
+            .spotify
+            .user_playlist_unfollow(&user_id, &playlist_id)
+            .await
+        {
+            Ok(_) => {
+                self.get_current_user_playlists().await;
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        }
+    }
+
+    async fn made_for_you_search_and_add(
+        &mut self,
+        search_string: String,
+        country: Option<Country>,
+    ) {
+        const SPOTIFY_ID: &str = "spotify";
+
+        match self
+            .spotify
+            .search_playlist(&search_string, self.large_search_limit, 0, country)
+            .await
+        {
+            Ok(mut search_playlists) => {
+                let mut filtered_playlists = search_playlists
+                    .playlists
+                    .items
+                    .iter()
+                    .filter(|playlist| {
+                        playlist.owner.id == SPOTIFY_ID && playlist.name == search_string
+                    })
+                    .map(|playlist| playlist.to_owned())
+                    .collect::<Vec<SimplifiedPlaylist>>();
+
+                let mut app = self.app.lock().await;
+                if !app.library.made_for_you_playlists.pages.is_empty() {
+                    app.library
+                        .made_for_you_playlists
+                        .get_mut_results(None)
+                        .unwrap()
+                        .items
+                        .append(&mut filtered_playlists);
+                } else {
+                    search_playlists.playlists.items = filtered_playlists;
+                    app.library
+                        .made_for_you_playlists
+                        .add_pages(search_playlists.playlists);
+                }
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        }
+    }
+
+    async fn get_audio_analysis(&mut self, uri: String) {
+        match self.spotify.audio_analysis(&uri).await {
+            Ok(result) => {
+                let mut app = self.app.lock().await;
+                app.audio_analysis = Some(result);
+                app.push_navigation_stack(RouteId::Analysis, ActiveBlock::Analysis);
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        }
+    }
+
+    async fn get_current_user_playlists(&mut self) {
+        let playlists = self
+            .spotify
+            .current_user_playlists(self.large_search_limit, None)
+            .await;
+
+        match playlists {
+            Ok(p) => {
+                let mut app = self.app.lock().await;
+                app.playlists = Some(p);
+                // Select the first playlist
+                app.selected_playlist_index = Some(0);
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        };
+    }
+
+    async fn get_recently_played(&mut self) {
+        match self
+            .spotify
+            .current_user_recently_played(self.large_search_limit)
+            .await
+        {
+            Ok(result) => {
+                let track_ids = result
+                    .items
+                    .iter()
+                    .filter_map(|item| item.track.id.clone())
+                    .collect::<Vec<String>>();
+
+                self.current_user_saved_tracks_contains(track_ids).await;
+
+                let mut app = self.app.lock().await;
+
+                app.recently_played.result = Some(result.clone());
+                app.push_navigation_stack(RouteId::RecentlyPlayed, ActiveBlock::RecentlyPlayed);
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        }
+    }
+
+    async fn get_album(&mut self, album_id: String) {
+        match self.spotify.album(&album_id).await {
+            Ok(album) => {
+                let selected_album = SelectedFullAlbum {
+                    album,
+                    selected_index: 0,
+                };
+
+                let mut app = self.app.lock().await;
+
+                app.selected_album_full = Some(selected_album);
+                app.album_table_context = AlbumTableContext::Full;
+                app.push_navigation_stack(RouteId::AlbumTracks, ActiveBlock::AlbumTracks);
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        }
+    }
+
+    async fn set_device_id_in_config(&mut self, device_id: String) {
+        match self.client_config.set_device_id(device_id) {
+            Ok(()) => {
+                let mut app = self.app.lock().await;
+                app.pop_navigation_stack();
+            }
+            Err(e) => {
+                self.handle_error(e).await;
+            }
+        };
+    }
+
+    async fn refresh_authentication(&mut self) {
+        if let Some(new_token_info) = get_token(&mut self.oauth).await {
+            let (new_spotify, new_token_expiry) = get_spotify(new_token_info);
+            self.spotify = new_spotify;
+            self.spotify_token_expiry = new_token_expiry;
+        } else {
+            println!("\nFailed to refresh authentication token");
+            // TODO panic!
+        }
+    }
+}

--- a/src/redirect_uri.rs
+++ b/src/redirect_uri.rs
@@ -1,4 +1,4 @@
-use rspotify::spotify::{oauth2::SpotifyOAuth, util::request_token};
+use rspotify::{oauth2::SpotifyOAuth, util::request_token};
 use std::{
     io::prelude::*,
     net::{TcpListener, TcpStream},

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -9,7 +9,7 @@ use super::{
     banner::BANNER,
 };
 use help::get_help_docs;
-use rspotify::spotify::senum::RepeatState;
+use rspotify::senum::RepeatState;
 use tui::{
     backend::Backend,
     layout::{Constraint, Direction, Layout, Rect},
@@ -134,15 +134,21 @@ where
         )
         .render(f, chunks[0]);
 
+    let help_block_text = if app.is_loading {
+        (app.user_config.theme.hint, "Loading...")
+    } else {
+        (app.user_config.theme.inactive, "Type ?")
+    };
+
     let block = Block::default()
         .title("Help")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(app.user_config.theme.inactive))
-        .title_style(Style::default().fg(app.user_config.theme.inactive));
+        .border_style(Style::default().fg(help_block_text.0))
+        .title_style(Style::default().fg(help_block_text.0));
 
-    Paragraph::new([Text::raw("Type ?")].iter())
+    Paragraph::new([Text::raw(help_block_text.1)].iter())
         .block(block)
-        .style(Style::default().fg(app.user_config.theme.inactive))
+        .style(Style::default().fg(help_block_text.0))
         .render(f, chunks[1]);
 }
 
@@ -800,7 +806,7 @@ where
         .margin(5)
         .split(f.size());
 
-    let mut playing_text = vec![
+    let playing_text = vec![
         Text::raw("Api response: "),
         Text::styled(&app.api_error, Style::default().fg(app.user_config.theme.error_text)),
         Text::styled(
@@ -822,13 +828,6 @@ Hint: a playback device must be either an official spotify client or a light wei
             Style::default().fg(app.user_config.theme.inactive),
         ),
     ];
-
-    if app.client_config.device_id.is_none() {
-        playing_text.push(Text::styled(
-            "\nNo playback device is selected - follow point 2 above",
-            Style::default().fg(app.user_config.theme.hint),
-        ))
-    }
 
     Paragraph::new(playing_text.iter())
         .wrap(true)

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -1,6 +1,6 @@
 use super::super::app::{ActiveBlock, App, ArtistBlock, SearchResultBlock};
 use crate::user_config::Theme;
-use rspotify::spotify::model::artist::SimplifiedArtist;
+use rspotify::model::artist::SimplifiedArtist;
 use tui::style::Style;
 
 pub const SMALL_TERMINAL_HEIGHT: u16 = 45;

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -165,6 +165,7 @@ pub struct KeyBindingsString {
     audio_analysis: Option<String>,
 }
 
+#[derive(Clone)]
 pub struct KeyBindings {
     pub back: Key,
     pub jump_to_album: Key,
@@ -194,6 +195,7 @@ pub struct BehaviorConfigString {
     pub tick_rate_milliseconds: Option<u64>,
 }
 
+#[derive(Clone)]
 pub struct BehaviorConfig {
     pub seek_milliseconds: u32,
     pub volume_increment: u8,
@@ -207,6 +209,7 @@ pub struct UserConfigString {
     theme: Option<UserTheme>,
 }
 
+#[derive(Clone)]
 pub struct UserConfig {
     pub keys: KeyBindings,
     pub theme: Theme,


### PR DESCRIPTION
This is a huge PR that changes the architecture of the app considerably.

The idea is to create thread that will handle network events, while the main thread will handle the UI rendering loop.

The implication of this change is that the UI thread will disptach (or send) messages to the network thread for it then to execute the async action.

Thus, slow network calls will no longer block the UI thread meaning the app should feel more responsive on slow connections.

I have tested on very slow internet connections and can see these changes will drastically improve both #92 and #207. 

Given the scale of these changes, I encourage anyone to checkout this branch and test!

