### PR TITLE
Correctly handle playlist unfollowing

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -777,6 +777,19 @@ impl App {
     }
   }
 
+  pub fn user_unfollow_playlist_search_result(&mut self) {
+    if let (Some(playlists), Some(selected_index), Some(user)) = (
+      &self.search_results.playlists,
+      self.search_results.selected_playlists_index,
+      &self.user,
+    ) {
+      let selected_playlist = &playlists.playlists.items[selected_index];
+      let selected_id = selected_playlist.id.clone();
+      let user_id = user.id.clone();
+      self.dispatch(IoEvent::UserUnfollowPlaylist(user_id, selected_id))
+    }
+  }
+
   pub fn get_made_for_you(&mut self) {
     // TODO: replace searches when relevant endpoint is added
     const DISCOVER_WEEKLY: &str = "Discover Weekly";

--- a/src/handlers/search_results.rs
+++ b/src/handlers/search_results.rs
@@ -444,7 +444,7 @@ pub fn handler(key: Key, app: &mut App) {
       SearchResultBlock::SongSearch => {}
       SearchResultBlock::ArtistSearch => app.user_unfollow_artists(ActiveBlock::SearchResultBlock),
       SearchResultBlock::PlaylistSearch => {
-        app.user_unfollow_playlist();
+        app.user_unfollow_playlist_search_result();
       }
       SearchResultBlock::Empty => {}
     },


### PR DESCRIPTION
**How to reproduce the problem:**
1) Follow any playlist, it will appear in the left frame "Playlists"
2) Search for any other playlist and select it in the corresponding frame
3) Press 'D'
The one that you were following will disappear. 

A simpler case - have no playlists followed and press 'D' - the application will panic with an out of bounds.

Unfollowing playlists from search results should be handled separately.