### PR TITLE
Bump tui from 0.8.0 to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,42 +265,17 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5750773d74a7dc612eac2ded3f55e9cdeeaa072210cd17c0192aedb48adb3618"
-dependencies = [
- "bitflags",
- "crossterm_winapi 0.5.1",
- "lazy_static",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccdd8ef63a44e821956c6a276eca0faaa889d6a067dfcdbd5bfe85dce3a1d250"
 dependencies = [
  "bitflags",
- "crossterm_winapi 0.6.1",
+ "crossterm_winapi",
  "lazy_static",
  "libc",
  "mio",
  "parking_lot",
  "signal-hook",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8777c700901e2d5b50c406f736ed6b8f9e43645c7e104ddb74f8bc42b8ae62f6"
-dependencies = [
  "winapi 0.3.8",
 ]
 
@@ -759,6 +734,15 @@ name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -1434,7 +1418,7 @@ dependencies = [
  "dotenv",
  "env_logger",
  "failure",
- "itertools",
+ "itertools 0.8.2",
  "lazy_static",
  "log",
  "percent-encoding 1.0.1",
@@ -1625,7 +1609,7 @@ dependencies = [
  "backtrace",
  "clap",
  "clipboard",
- "crossterm 0.17.3",
+ "crossterm",
  "dirs",
  "proc-macro2 1.0.10",
  "rand 0.7.3",
@@ -1842,16 +1826,15 @@ checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 
 [[package]]
 name = "tui"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b871b61f4c4b81e630215cd12e0ec29953d4545898e21a9e023b7520a74a9f9"
+checksum = "b7de74b91c6cb83119a2140e7c215d95d9e54db27b58a500a2cbdeec4987b0a2"
 dependencies = [
  "bitflags",
  "cassowary",
- "crossterm 0.14.2",
+ "crossterm",
  "either",
- "itertools",
- "log",
+ "itertools 0.9.0",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 rspotify = "0.9.0"
-tui = { version = "0.8.0", features = ["crossterm"], default-features = false }
+tui = { version = "0.9.0", features = ["crossterm"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
@@ -24,10 +24,10 @@ clap = "2.33.0"
 unicode-width = "0.1.7"
 backtrace = "0.3.46"
 clipboard = "0.5.0"
-crossterm =  "0.17"
+crossterm = "0.17"
 tokio = { version = "0.2", features = ["full"] }
 proc-macro2 = "1.0.10"
-rand="0.7.3"
+rand = "0.7.3"
 anyhow = "1.0.28"
 
 [[bin]]

--- a/src/ui/audio_analysis.rs
+++ b/src/ui/audio_analysis.rs
@@ -4,7 +4,7 @@ use tui::{
   backend::Backend,
   layout::{Constraint, Direction, Layout},
   style::Style,
-  widgets::{BarChart, Block, Borders, Paragraph, Text, Widget},
+  widgets::{BarChart, Block, Borders, Paragraph, Text},
   Frame,
 };
 const PITCHES: [&str; 12] = [
@@ -76,29 +76,27 @@ where
       .find(|section| section.start >= progress_seconds);
 
     if let (Some(segment), Some(section)) = (segment, section) {
-      Paragraph::new(
-        [
-          Text::raw(format!(
-            "Tempo: {} (confidence {:.0}%)\n",
-            section.tempo,
-            section.tempo_confidence * 100.0
-          )),
-          Text::raw(format!(
-            "Key: {} (confidence {:.0}%)\n",
-            PITCHES.get(section.key as usize).unwrap_or(&PITCHES[0]),
-            section.key_confidence * 100.0
-          )),
-          Text::raw(format!(
-            "Time Signature: {}/4 (confidence {:.0}%)\n",
-            section.time_signature,
-            section.time_signature_confidence * 100.0
-          )),
-        ]
-        .iter(),
-      )
-      .block(analysis_block)
-      .style(Style::default().fg(app.user_config.theme.text))
-      .render(f, chunks[0]);
+      let texts = [
+        Text::raw(format!(
+          "Tempo: {} (confidence {:.0}%)\n",
+          section.tempo,
+          section.tempo_confidence * 100.0
+        )),
+        Text::raw(format!(
+          "Key: {} (confidence {:.0}%)\n",
+          PITCHES.get(section.key as usize).unwrap_or(&PITCHES[0]),
+          section.key_confidence * 100.0
+        )),
+        Text::raw(format!(
+          "Time Signature: {}/4 (confidence {:.0}%)\n",
+          section.time_signature,
+          section.time_signature_confidence * 100.0
+        )),
+      ];
+      let p = Paragraph::new(texts.iter())
+        .block(analysis_block)
+        .style(Style::default().fg(app.user_config.theme.text));
+      f.render_widget(p, chunks[0]);
 
       let data: Vec<(&str, u64)> = segment
         .pitches
@@ -115,7 +113,7 @@ where
         })
         .collect();
 
-      BarChart::default()
+      let analysis_bar = BarChart::default()
         .block(bar_chart_block)
         .data(&data)
         .bar_width(width as u16)
@@ -124,14 +122,14 @@ where
           Style::default()
             .fg(app.user_config.theme.analysis_bar_text)
             .bg(app.user_config.theme.analysis_bar),
-        )
-        .render(f, chunks[1]);
+        );
+      f.render_widget(analysis_bar, chunks[1]);
     } else {
-      empty_analysis_block().render(f, chunks[0]);
-      empty_pitches_block().render(f, chunks[1]);
+      f.render_widget(empty_analysis_block(), chunks[0]);
+      f.render_widget(empty_pitches_block(), chunks[1]);
     };
   } else {
-    empty_analysis_block().render(f, chunks[0]);
-    empty_pitches_block().render(f, chunks[1]);
+    f.render_widget(empty_analysis_block(), chunks[0]);
+    f.render_widget(empty_pitches_block(), chunks[1]);
   }
 }


### PR DESCRIPTION
Replace all `Widget.render` calls by `Frame::render_widget` and refactor
to remove newly introduced lifetimes issues.

I've kept the diff to a minimum. In particular, I'm not taking advantage of the new `ListState` associated to the `List` widget that would allow a better scrolling experience because it is likely that it would require changes in the `App` struct and I'm not familiar enough with the code to do that kind of refactor.