### PR TITLE
Fix device selection screen formatting

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1077,10 +1077,10 @@ where
     .split(f.size());
 
   let device_instructions = [
-        Text::raw("To play tracks, please select a device."),
-        Text::raw("Use `j/k` or up/down arrow keys to move up and down and <Enter> to select"),
-        Text::raw("Your choice here will be cached so you can jump straight back in when you next open `spotify-tui`."),
-        Text::raw("You can change the playback device at any time by pressing `d`."),
+        Text::raw("To play tracks, please select a device.  \
+          Use `j/k` or up/down arrow keys to move up and down and <Enter> to select.  \
+          Your choice here will be cached so you can jump straight back in when you next open `spotify-tui`.  \
+          You can change the playback device at any time by pressing `d`."),
     ];
 
   let instructions = Paragraph::new(device_instructions.iter())


### PR DESCRIPTION
Very minor thing I noticed when setting up - the text looks a bit wonky in the device selection screen.

Currently:
![image](https://user-images.githubusercontent.com/34804052/80241486-ab14ad80-8631-11ea-9493-eb0d38abb29f.png)

I just made it one string instead with proper spacing and added a period, which (IMO) looks nicer:

![image](https://user-images.githubusercontent.com/34804052/80241553-c089d780-8631-11ea-824a-0cb05f8cc6b0.png)
