### PR TITLE
Fix token expiration time

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -22,7 +22,7 @@ use std::sync::mpsc::Sender;
 use std::{
   cmp::{max, min},
   collections::HashSet,
-  time::Instant,
+  time::{Instant, SystemTime},
 };
 use tui::layout::Rect;
 
@@ -287,7 +287,7 @@ pub struct App {
   pub is_loading: bool,
   io_tx: Option<Sender<IoEvent>>,
   pub is_fetching_current_playback: bool,
-  pub spotify_token_expiry: Instant,
+  pub spotify_token_expiry: SystemTime,
   pub dialog: Option<String>,
   pub confirm: bool,
 }
@@ -362,7 +362,7 @@ impl Default for App {
       is_loading: false,
       io_tx: None,
       is_fetching_current_playback: false,
-      spotify_token_expiry: Instant::now(),
+      spotify_token_expiry: SystemTime::now(),
       dialog: None,
       confirm: false,
     }
@@ -373,7 +373,7 @@ impl App {
   pub fn new(
     io_tx: Sender<IoEvent>,
     user_config: UserConfig,
-    spotify_token_expiry: Instant,
+    spotify_token_expiry: SystemTime,
   ) -> App {
     App {
       io_tx: Some(io_tx),

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ use std::{
   panic::{self, PanicInfo},
   path::PathBuf,
   sync::Arc,
-  time::Instant,
+  time::SystemTime,
 };
 use tokio::sync::Mutex;
 use tui::{
@@ -300,7 +300,7 @@ async fn start_ui(user_config: UserConfig, app: &Arc<Mutex<App>>) -> Result<()> 
     ))?;
 
     // Handle authentication refresh
-    if Instant::now() > app.spotify_token_expiry {
+    if SystemTime::now() > app.spotify_token_expiry {
       app.dispatch(IoEvent::RefreshAuthentication);
     }
 


### PR DESCRIPTION
When using the cached Spotify token, the expiration time was not correctly computed. As a consequence, the re-authentication was not triggered.

I had to move from `Instant` to `SystemTime`. I hope this is OK.

Closes #410 