### PR TITLE
Add user configuration toggle for the loading indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ behavior:
   volume_increment: 10
   # The lower the number the higher the "frames per second". You can decrease this number so that the audio visualisation is smoother but this can be expensive!
   tick_rate_milliseconds: 250
+  # controls whether to show a loading indicator in the top right of the UI whenever communicating with Spotify API
+  show_loading_indicator: true
 
 keybindings:
   # Key stroke can be used if it only uses two keys:

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -134,7 +134,8 @@ where
   );
   f.render_widget(input, chunks[0]);
 
-  let help_block_text = if app.is_loading {
+  let show_loading = app.is_loading && app.user_config.behavior.show_loading_indicator;
+  let help_block_text = if show_loading {
     (app.user_config.theme.hint, "Loading...")
   } else {
     (app.user_config.theme.inactive, "Type ?")

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -192,6 +192,7 @@ pub struct BehaviorConfigString {
   pub seek_milliseconds: Option<u32>,
   pub volume_increment: Option<u8>,
   pub tick_rate_milliseconds: Option<u64>,
+  pub show_loading_indicator: Option<bool>,
 }
 
 #[derive(Clone)]
@@ -199,6 +200,7 @@ pub struct BehaviorConfig {
   pub seek_milliseconds: u32,
   pub volume_increment: u8,
   pub tick_rate_milliseconds: u64,
+  pub show_loading_indicator: bool,
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -246,6 +248,7 @@ impl UserConfig {
         seek_milliseconds: 5 * 1000,
         volume_increment: 10,
         tick_rate_milliseconds: 250,
+        show_loading_indicator: true,
       },
       path_to_config: None,
     }
@@ -357,6 +360,10 @@ impl UserConfig {
       } else {
         self.behavior.tick_rate_milliseconds = tick_rate;
       }
+    }
+
+    if let Some(loading_indicator) = behavior_config.show_loading_indicator {
+      self.behavior.show_loading_indicator = loading_indicator;
     }
 
     Ok(())


### PR DESCRIPTION
This new setting, `show_loading_indicator`, can be added to the behavior section
of the user configuration. Defaults to `true` to maintain existing behavior of
showing the loading indicator. Set to `false` to disable the loading indicator.

[Resolves #420]