### PR TITLE
Remove proc-macro2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,7 +1620,6 @@ dependencies = [
  "clipboard",
  "crossterm",
  "dirs",
- "proc-macro2 1.0.12",
  "rand 0.7.3",
  "rspotify",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ backtrace = "0.3.46"
 clipboard = "0.5.0"
 crossterm = "0.17"
 tokio = { version = "0.2", features = ["full"] }
-proc-macro2 = "1.0.12"
 rand = "0.7.3"
 anyhow = "1.0.28"
 


### PR DESCRIPTION
This dep is not explicitly used in the source code and was added a while back to resolve a dependancy version locking issue. 

This seems to not be the case anymore though, so I'm removing it.