### PR TITLE
Use upstream rspotify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,7 +1431,8 @@ dependencies = [
 [[package]]
 name = "rspotify"
 version = "0.9.0"
-source = "git+https://github.com/Rigellute/rspotify#8d15009ea8e457ef5827334f22fef7e55b34c6b3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29b79da3557219b1ea44609ae2bdddbe8f0cc71188ab863cc47d98e8a1d6eb5"
 dependencies = [
  "base64 0.10.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rspotify = { git = "https://github.com/Rigellute/rspotify" }
+rspotify = "0.9.0"
 tui = { version = "0.9.5", features = ["crossterm"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/ui/audio_analysis.rs
+++ b/src/ui/audio_analysis.rs
@@ -69,30 +69,28 @@ where
     let segment = analysis
       .segments
       .iter()
-      .find(|segment| segment.start.unwrap_or(0.0) >= progress_seconds);
+      .find(|segment| segment.start >= progress_seconds);
     let section = analysis
       .sections
       .iter()
-      .find(|section| section.start.unwrap_or(0.0) >= progress_seconds);
+      .find(|section| section.start >= progress_seconds);
 
     if let (Some(segment), Some(section)) = (segment, section) {
       let texts = [
         Text::raw(format!(
           "Tempo: {} (confidence {:.0}%)\n",
-          section.tempo.unwrap_or(0.0),
-          section.tempo_confidence.unwrap_or(0.0) * 100.0
+          section.tempo,
+          section.tempo_confidence * 100.0
         )),
         Text::raw(format!(
           "Key: {} (confidence {:.0}%)\n",
-          PITCHES
-            .get(section.key.unwrap_or(0) as usize)
-            .unwrap_or(&PITCHES[0]),
-          section.key_confidence.unwrap_or(0.0) * 100.0
+          PITCHES.get(section.key as usize).unwrap_or(&PITCHES[0]),
+          section.key_confidence * 100.0
         )),
         Text::raw(format!(
           "Time Signature: {}/4 (confidence {:.0}%)\n",
-          section.time_signature.unwrap_or(0),
-          section.time_signature_confidence.unwrap_or(0.0) * 100.0
+          section.time_signature,
+          section.time_signature_confidence * 100.0
         )),
       ];
       let p = Paragraph::new(texts.iter())
@@ -103,7 +101,6 @@ where
       let data: Vec<(&str, u64)> = segment
         .clone()
         .pitches
-        .unwrap_or_default()
         .iter()
         .enumerate()
         .map(|(index, pitch)| {


### PR DESCRIPTION
The Spotify API has fixed the audio analysis endpoint on their end, so
my fork of rspotify is no longer needed.

Closes #437