### PR TITLE
Simple change of layout 

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -186,7 +186,7 @@ where
           Constraint::Min(1),
           Constraint::Length(6),
         ]
-        .as_ref()
+        .as_ref(),
       )
       .margin(margin)
       .split(f.size());

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -20,7 +20,7 @@ use tui::{
 use util::{
   create_artist_string, display_track_progress, get_artist_highlight_state, get_color,
   get_percentage_width, get_search_results_highlight_state, get_track_progress_percentage,
-  millis_to_minutes,
+  millis_to_minutes, SMALL_TERMINAL_WIDTH,
 };
 
 pub enum TableId {
@@ -111,9 +111,14 @@ pub fn draw_input_and_help_box<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rec
 where
   B: Backend,
 {
+  // Check for the width and change the contraints accordingly
   let chunks = Layout::default()
     .direction(Direction::Horizontal)
-    .constraints([Constraint::Percentage(65), Constraint::Percentage(35)].as_ref())
+    .constraints(if app.size.width >= SMALL_TERMINAL_WIDTH {
+      [Constraint::Percentage(65), Constraint::Percentage(35)].as_ref()
+    } else {
+      [Constraint::Percentage(90), Constraint::Percentage(10)].as_ref()
+    })
     .split(layout_chunk);
 
   let current_route = app.get_current_route();
@@ -159,17 +164,42 @@ where
   B: Backend,
 {
   let margin = util::get_main_layout_margin(app);
-  let parent_layout = Layout::default()
-    .direction(Direction::Vertical)
-    .constraints([Constraint::Min(1), Constraint::Length(6)].as_ref())
-    .margin(margin)
-    .split(f.size());
+  // Responsive layout: new one kicks in at width 150 or higher
+  if app.size.width >= SMALL_TERMINAL_WIDTH {
+    let parent_layout = Layout::default()
+      .direction(Direction::Vertical)
+      .constraints([Constraint::Min(1), Constraint::Length(6)].as_ref())
+      .margin(margin)
+      .split(f.size());
 
-  // Nested main block with potential routes
-  draw_routes(f, app, parent_layout[0]);
+    // Nested main block with potential routes
+    draw_routes(f, app, parent_layout[0]);
 
-  // Currently playing
-  draw_playbar(f, app, parent_layout[1]);
+    // Currently playing
+    draw_playbar(f, app, parent_layout[1]);
+  } else {
+    let parent_layout = Layout::default()
+      .direction(Direction::Vertical)
+      .constraints(
+        [
+          Constraint::Length(3),
+          Constraint::Min(1),
+          Constraint::Length(6),
+        ]
+        .as_ref()
+      )
+      .margin(margin)
+      .split(f.size());
+
+    // Search input and help
+    draw_input_and_help_box(f, app, parent_layout[0]);
+
+    // Nested main block with potential routes
+    draw_routes(f, app, parent_layout[1]);
+
+    // Currently playing
+    draw_playbar(f, app, parent_layout[2]);
+  }
 
   // Possibly draw confirm dialog
   draw_dialog(f, app);
@@ -280,22 +310,34 @@ pub fn draw_user_block<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
 where
   B: Backend,
 {
-  let chunks = Layout::default()
-    .direction(Direction::Vertical)
-    .constraints(
-      [
-        Constraint::Length(3),
-        Constraint::Percentage(30),
-        Constraint::Percentage(70),
-      ]
-      .as_ref(),
-    )
-    .split(layout_chunk);
+  // Check for width to make a responsive layout
+  if app.size.width >= SMALL_TERMINAL_WIDTH {
+    let chunks = Layout::default()
+      .direction(Direction::Vertical)
+      .constraints(
+        [
+          Constraint::Length(3),
+          Constraint::Percentage(30),
+          Constraint::Percentage(70),
+        ]
+        .as_ref(),
+      )
+      .split(layout_chunk);
 
-  // Search input and help
-  draw_input_and_help_box(f, app, chunks[0]);
-  draw_library_block(f, app, chunks[1]);
-  draw_playlist_block(f, app, chunks[2]);
+    // Search input and help
+    draw_input_and_help_box(f, app, chunks[0]);
+    draw_library_block(f, app, chunks[1]);
+    draw_playlist_block(f, app, chunks[2]);
+  } else {
+    let chunks = Layout::default()
+      .direction(Direction::Vertical)
+      .constraints([Constraint::Percentage(30), Constraint::Percentage(70)].as_ref())
+      .split(layout_chunk);
+
+    // Search input and help
+    draw_library_block(f, app, chunks[0]);
+    draw_playlist_block(f, app, chunks[1]);
+  }
 }
 
 pub fn draw_search_results<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -113,7 +113,7 @@ where
 {
   let chunks = Layout::default()
     .direction(Direction::Horizontal)
-    .constraints([Constraint::Percentage(90), Constraint::Percentage(10)].as_ref())
+    .constraints([Constraint::Percentage(65), Constraint::Percentage(35)].as_ref())
     .split(layout_chunk);
 
   let current_route = app.get_current_route();
@@ -161,25 +161,15 @@ where
   let margin = util::get_main_layout_margin(app);
   let parent_layout = Layout::default()
     .direction(Direction::Vertical)
-    .constraints(
-      [
-        Constraint::Length(3),
-        Constraint::Min(1),
-        Constraint::Length(6),
-      ]
-      .as_ref(),
-    )
+    .constraints([Constraint::Min(1), Constraint::Length(6)].as_ref())
     .margin(margin)
     .split(f.size());
 
-  // Search input and help
-  draw_input_and_help_box(f, app, parent_layout[0]);
-
   // Nested main block with potential routes
-  draw_routes(f, app, parent_layout[1]);
+  draw_routes(f, app, parent_layout[0]);
 
   // Currently playing
-  draw_playbar(f, app, parent_layout[2]);
+  draw_playbar(f, app, parent_layout[1]);
 
   // Possibly draw confirm dialog
   draw_dialog(f, app);
@@ -292,11 +282,20 @@ where
 {
   let chunks = Layout::default()
     .direction(Direction::Vertical)
-    .constraints([Constraint::Percentage(30), Constraint::Percentage(70)].as_ref())
+    .constraints(
+      [
+        Constraint::Length(3),
+        Constraint::Percentage(30),
+        Constraint::Percentage(70),
+      ]
+      .as_ref(),
+    )
     .split(layout_chunk);
 
-  draw_library_block(f, app, chunks[0]);
-  draw_playlist_block(f, app, chunks[1]);
+  // Search input and help
+  draw_input_and_help_box(f, app, chunks[0]);
+  draw_library_block(f, app, chunks[1]);
+  draw_playlist_block(f, app, chunks[2]);
 }
 
 pub fn draw_search_results<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -3,6 +3,7 @@ use crate::user_config::Theme;
 use rspotify::model::artist::SimplifiedArtist;
 use tui::style::Style;
 
+pub const SMALL_TERMINAL_WIDTH: u16 = 150;
 pub const SMALL_TERMINAL_HEIGHT: u16 = 45;
 
 pub fn get_search_results_highlight_state(


### PR DESCRIPTION
`draw_input_and_help_box` moved to `draw_user_block` so the search and help bar is reduced and the main panel is adjusted to fill that space. The constraints of size of both functions were tweaked as well to better fit the new layout. 

I feel this new layout does a better job at taking advantage of space as the strings we search are usually not that long and after some use of the client the help bar becomes more or less irrelevant. 

Here some screenshots 

Fullscreen in a 1080p monitor 
![Screenshot_full](https://user-images.githubusercontent.com/28630268/85188409-d69bc900-b26b-11ea-97e8-61a024c30633.png)


Halfscreen in a 1080p monitor 
![Screenshot_half ](https://user-images.githubusercontent.com/28630268/85188411-da2f5000-b26b-11ea-9e91-c8e03b14283f.png)

Current layout for comparison 
![old](https://user-images.githubusercontent.com/28630268/85189159-bff87080-b271-11ea-82cc-1b8a5656a0af.png)
