### PR TITLE
Add album artist field to full album view

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -566,6 +566,7 @@ where
               "".to_string(),
               item.track_number.to_string(),
               item.name.to_owned(),
+              create_artist_string(&item.artists),
               millis_to_minutes(u128::from(item.duration_ms)),
             ],
           })


### PR DESCRIPTION
This is shown in the Simplified context, but wasn't in the Full context.
This causes the undesired behavior that getting to an album from the
library context has a missing field (see #488).

Fixes #488