### PR TITLE
Upgrade rspotify to 0.10.0 (Podcast support)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "rspotify"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29b79da3557219b1ea44609ae2bdddbe8f0cc71188ab863cc47d98e8a1d6eb5"
+checksum = "eefd7bb58b714606b30a490f751d7926942e2874eef5e82934d60d7a4a68dca4"
 dependencies = [
  "base64 0.10.1",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rspotify = "0.9.0"
+rspotify = "0.10.0"
 tui = { version = "0.9.5", features = ["crossterm"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/handlers/basic_view.rs
+++ b/src/handlers/basic_view.rs
@@ -1,13 +1,22 @@
 use crate::{app::App, event::Key, network::IoEvent};
+use rspotify::model::{context::CurrentlyPlaybackContext, PlayingItem};
 
 pub fn handler(key: Key, app: &mut App) {
   if let Key::Char('s') = key {
-    if let Some(playing_context) = &app.current_playback_context {
-      if let Some(track) = &playing_context.clone().item {
-        if let Some(id) = &track.id {
-          app.dispatch(IoEvent::ToggleSaveTrack(id.to_string()));
+    if let Some(CurrentlyPlaybackContext {
+      item: Some(item), ..
+    }) = app.current_playback_context.to_owned()
+    {
+      match item {
+        PlayingItem::Track(track) => {
+          if let Some(track_id) = track.id {
+            app.dispatch(IoEvent::ToggleSaveTrack(track_id));
+          }
         }
-      }
-    }
+        PlayingItem::Episode(episode) => {
+          app.dispatch(IoEvent::ToggleSaveTrack(episode.id));
+        }
+      };
+    };
   }
 }

--- a/src/handlers/playbar.rs
+++ b/src/handlers/playbar.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use crate::event::Key;
 use crate::network::IoEvent;
+use rspotify::model::{context::CurrentlyPlaybackContext, PlayingItem};
 
 pub fn handler(key: Key, app: &mut App) {
   match key {
@@ -11,13 +12,21 @@ pub fn handler(key: Key, app: &mut App) {
       app.set_current_route_state(Some(ActiveBlock::Empty), Some(ActiveBlock::MyPlaylists));
     }
     Key::Char('s') => {
-      if let Some(playing_context) = &app.current_playback_context {
-        if let Some(track) = &playing_context.clone().item {
-          if let Some(id) = &track.id {
-            app.dispatch(IoEvent::ToggleSaveTrack(id.to_string()));
+      if let Some(CurrentlyPlaybackContext {
+        item: Some(item), ..
+      }) = app.current_playback_context.to_owned()
+      {
+        match item {
+          PlayingItem::Track(track) => {
+            if let Some(track_id) = track.id {
+              app.dispatch(IoEvent::ToggleSaveTrack(track_id));
+            }
           }
-        }
-      }
+          PlayingItem::Episode(episode) => {
+            app.dispatch(IoEvent::ToggleSaveTrack(episode.id));
+          }
+        };
+      };
     }
     _ => {}
   };

--- a/src/handlers/search_results.rs
+++ b/src/handlers/search_results.rs
@@ -14,7 +14,7 @@ fn handle_down_press_on_selected_block(app: &mut App) {
     SearchResultBlock::AlbumSearch => {
       if let Some(result) = &app.search_results.albums {
         let next_index = common_key_events::on_down_press_handler(
-          &result.albums.items,
+          &result.items,
           app.search_results.selected_album_index,
         );
         app.search_results.selected_album_index = Some(next_index);
@@ -23,7 +23,7 @@ fn handle_down_press_on_selected_block(app: &mut App) {
     SearchResultBlock::SongSearch => {
       if let Some(result) = &app.search_results.tracks {
         let next_index = common_key_events::on_down_press_handler(
-          &result.tracks.items,
+          &result.items,
           app.search_results.selected_tracks_index,
         );
         app.search_results.selected_tracks_index = Some(next_index);
@@ -32,7 +32,7 @@ fn handle_down_press_on_selected_block(app: &mut App) {
     SearchResultBlock::ArtistSearch => {
       if let Some(result) = &app.search_results.artists {
         let next_index = common_key_events::on_down_press_handler(
-          &result.artists.items,
+          &result.items,
           app.search_results.selected_artists_index,
         );
         app.search_results.selected_artists_index = Some(next_index);
@@ -41,7 +41,7 @@ fn handle_down_press_on_selected_block(app: &mut App) {
     SearchResultBlock::PlaylistSearch => {
       if let Some(result) = &app.search_results.playlists {
         let next_index = common_key_events::on_down_press_handler(
-          &result.playlists.items,
+          &result.items,
           app.search_results.selected_playlists_index,
         );
         app.search_results.selected_playlists_index = Some(next_index);
@@ -75,7 +75,7 @@ fn handle_up_press_on_selected_block(app: &mut App) {
     SearchResultBlock::AlbumSearch => {
       if let Some(result) = &app.search_results.albums {
         let next_index = common_key_events::on_up_press_handler(
-          &result.albums.items,
+          &result.items,
           app.search_results.selected_album_index,
         );
         app.search_results.selected_album_index = Some(next_index);
@@ -84,7 +84,7 @@ fn handle_up_press_on_selected_block(app: &mut App) {
     SearchResultBlock::SongSearch => {
       if let Some(result) = &app.search_results.tracks {
         let next_index = common_key_events::on_up_press_handler(
-          &result.tracks.items,
+          &result.items,
           app.search_results.selected_tracks_index,
         );
         app.search_results.selected_tracks_index = Some(next_index);
@@ -93,7 +93,7 @@ fn handle_up_press_on_selected_block(app: &mut App) {
     SearchResultBlock::ArtistSearch => {
       if let Some(result) = &app.search_results.artists {
         let next_index = common_key_events::on_up_press_handler(
-          &result.artists.items,
+          &result.items,
           app.search_results.selected_artists_index,
         );
         app.search_results.selected_artists_index = Some(next_index);
@@ -102,7 +102,7 @@ fn handle_up_press_on_selected_block(app: &mut App) {
     SearchResultBlock::PlaylistSearch => {
       if let Some(result) = &app.search_results.playlists {
         let next_index = common_key_events::on_up_press_handler(
-          &result.playlists.items,
+          &result.items,
           app.search_results.selected_playlists_index,
         );
         app.search_results.selected_playlists_index = Some(next_index);
@@ -164,25 +164,25 @@ fn handle_middle_press_on_selected_block(app: &mut App) {
   match app.search_results.selected_block {
     SearchResultBlock::AlbumSearch => {
       if let Some(result) = &app.search_results.albums {
-        let next_index = common_key_events::on_middle_press_handler(&result.albums.items);
+        let next_index = common_key_events::on_middle_press_handler(&result.items);
         app.search_results.selected_album_index = Some(next_index);
       }
     }
     SearchResultBlock::SongSearch => {
       if let Some(result) = &app.search_results.tracks {
-        let next_index = common_key_events::on_middle_press_handler(&result.tracks.items);
+        let next_index = common_key_events::on_middle_press_handler(&result.items);
         app.search_results.selected_tracks_index = Some(next_index);
       }
     }
     SearchResultBlock::ArtistSearch => {
       if let Some(result) = &app.search_results.artists {
-        let next_index = common_key_events::on_middle_press_handler(&result.artists.items);
+        let next_index = common_key_events::on_middle_press_handler(&result.items);
         app.search_results.selected_artists_index = Some(next_index);
       }
     }
     SearchResultBlock::PlaylistSearch => {
       if let Some(result) = &app.search_results.playlists {
-        let next_index = common_key_events::on_middle_press_handler(&result.playlists.items);
+        let next_index = common_key_events::on_middle_press_handler(&result.items);
         app.search_results.selected_playlists_index = Some(next_index);
       }
     }
@@ -194,25 +194,25 @@ fn handle_low_press_on_selected_block(app: &mut App) {
   match app.search_results.selected_block {
     SearchResultBlock::AlbumSearch => {
       if let Some(result) = &app.search_results.albums {
-        let next_index = common_key_events::on_low_press_handler(&result.albums.items);
+        let next_index = common_key_events::on_low_press_handler(&result.items);
         app.search_results.selected_album_index = Some(next_index);
       }
     }
     SearchResultBlock::SongSearch => {
       if let Some(result) = &app.search_results.tracks {
-        let next_index = common_key_events::on_low_press_handler(&result.tracks.items);
+        let next_index = common_key_events::on_low_press_handler(&result.items);
         app.search_results.selected_tracks_index = Some(next_index);
       }
     }
     SearchResultBlock::ArtistSearch => {
       if let Some(result) = &app.search_results.artists {
-        let next_index = common_key_events::on_low_press_handler(&result.artists.items);
+        let next_index = common_key_events::on_low_press_handler(&result.items);
         app.search_results.selected_artists_index = Some(next_index);
       }
     }
     SearchResultBlock::PlaylistSearch => {
       if let Some(result) = &app.search_results.playlists {
-        let next_index = common_key_events::on_low_press_handler(&result.playlists.items);
+        let next_index = common_key_events::on_low_press_handler(&result.items);
         app.search_results.selected_playlists_index = Some(next_index);
       }
     }
@@ -227,7 +227,7 @@ fn handle_enter_event_on_selected_block(app: &mut App) {
         &app.search_results.selected_album_index,
         &app.search_results.albums,
       ) {
-        if let Some(album) = albums_result.albums.items.get(index.to_owned()).cloned() {
+        if let Some(album) = albums_result.items.get(index.to_owned()).cloned() {
           app.track_table.context = Some(TrackTableContext::AlbumSearch);
           app.dispatch(IoEvent::GetAlbumTracks(Box::new(album)));
         };
@@ -238,7 +238,6 @@ fn handle_enter_event_on_selected_block(app: &mut App) {
       let tracks = app.search_results.tracks.clone();
       let track_uris = tracks.map(|tracks| {
         tracks
-          .tracks
           .items
           .into_iter()
           .map(|track| track.uri)
@@ -249,7 +248,7 @@ fn handle_enter_event_on_selected_block(app: &mut App) {
     SearchResultBlock::ArtistSearch => {
       if let Some(index) = &app.search_results.selected_artists_index {
         if let Some(result) = app.search_results.artists.clone() {
-          if let Some(artist) = result.artists.items.get(index.to_owned()) {
+          if let Some(artist) = result.items.get(index.to_owned()) {
             app.get_artist(artist.id.clone(), artist.name.clone());
             app.push_navigation_stack(RouteId::Artist, ActiveBlock::ArtistBlock);
           };
@@ -261,7 +260,7 @@ fn handle_enter_event_on_selected_block(app: &mut App) {
         app.search_results.selected_playlists_index,
         &app.search_results.playlists,
       ) {
-        if let Some(playlist) = playlists_result.playlists.items.get(index) {
+        if let Some(playlist) = playlists_result.items.get(index) {
           // Go to playlist tracks table
           app.track_table.context = Some(TrackTableContext::PlaylistSearch);
           let playlist_id = playlist.id.to_owned();
@@ -321,7 +320,7 @@ fn handle_recommended_tracks(app: &mut App) {
     SearchResultBlock::SongSearch => {
       if let Some(index) = &app.search_results.selected_tracks_index {
         if let Some(result) = app.search_results.tracks.clone() {
-          if let Some(track) = result.tracks.items.get(index.to_owned()) {
+          if let Some(track) = result.items.get(index.to_owned()) {
             let track_id_list: Option<Vec<String>> = match &track.id {
               Some(id) => Some(vec![id.to_string()]),
               None => None,
@@ -336,7 +335,7 @@ fn handle_recommended_tracks(app: &mut App) {
     SearchResultBlock::ArtistSearch => {
       if let Some(index) = &app.search_results.selected_artists_index {
         if let Some(result) = app.search_results.artists.clone() {
-          if let Some(artist) = result.artists.items.get(index.to_owned()) {
+          if let Some(artist) = result.items.get(index.to_owned()) {
             let artist_id_list: Option<Vec<String>> = Some(vec![artist.id.clone()]);
             app.recommendations_context = Some(RecommendationsContext::Artist);
             app.recommendations_seed = artist.name.clone();
@@ -451,7 +450,7 @@ pub fn handler(key: Key, app: &mut App) {
           &app.search_results.playlists,
           app.search_results.selected_playlists_index,
         ) {
-          let selected_playlist = &playlists.playlists.items[selected_index].name;
+          let selected_playlist = &playlists.items[selected_index].name;
           app.dialog = Some(selected_playlist.clone());
           app.confirm = false;
 

--- a/src/handlers/track_table.rs
+++ b/src/handlers/track_table.rs
@@ -205,7 +205,6 @@ fn play_random_song(app: &mut App) {
         ) {
           (Some(selected_playlist_index), Some(playlist_result)) => {
             if let Some(selected_playlist) = playlist_result
-              .playlists
               .items
               .get(selected_playlist_index.to_owned())
             {
@@ -382,7 +381,6 @@ fn on_enter(app: &mut App) {
           ) {
             (Some(selected_playlist_index), Some(playlist_result)) => {
               if let Some(selected_playlist) = playlist_result
-                .playlists
                 .items
                 .get(selected_playlist_index.to_owned())
               {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -9,6 +9,7 @@ use super::{
   banner::BANNER,
 };
 use help::get_help_docs;
+use rspotify::model::PlayingItem;
 use rspotify::senum::RepeatState;
 use tui::{
   backend::Backend,
@@ -317,12 +318,16 @@ where
     let currently_playing_id = app
       .current_playback_context
       .clone()
-      .and_then(|context| context.item.and_then(|item| item.id))
+      .and_then(|context| {
+        context.item.and_then(|item| match item {
+          PlayingItem::Track(track) => track.id,
+          PlayingItem::Episode(episode) => Some(episode.id),
+        })
+      })
       .unwrap_or_else(|| "".to_string());
 
     let songs = match &app.search_results.tracks {
-      Some(r) => r
-        .tracks
+      Some(tracks) => tracks
         .items
         .iter()
         .map(|item| {
@@ -354,8 +359,7 @@ where
     );
 
     let artists = match &app.search_results.artists {
-      Some(r) => r
-        .artists
+      Some(artists) => artists
         .items
         .iter()
         .map(|item| {
@@ -388,8 +392,7 @@ where
       .split(chunks[1]);
 
     let albums = match &app.search_results.albums {
-      Some(r) => r
-        .albums
+      Some(albums) => albums
         .items
         .iter()
         .map(|item| {
@@ -421,8 +424,7 @@ where
     );
 
     let playlists = match &app.search_results.playlists {
-      Some(r) => r
-        .playlists
+      Some(playlists) => playlists
         .items
         .iter()
         .map(|item| item.name.to_owned())
@@ -814,19 +816,35 @@ where
         .title(&title)
         .title_style(get_color(highlight_state, app.user_config.theme))
         .border_style(get_color(highlight_state, app.user_config.theme));
+
       f.render_widget(title_block, layout_chunk);
 
-      let track_name = if app
-        .liked_song_ids_set
-        .contains(&track_item.id.clone().unwrap_or_else(|| "".to_string()))
-      {
-        format!("♥ {}", &track_item.name)
+      let (item_id, name, duration_ms) = match track_item {
+        PlayingItem::Track(track) => (
+          track.id.to_owned().unwrap_or_else(|| "".to_string()),
+          track.name.to_owned(),
+          track.duration_ms,
+        ),
+        PlayingItem::Episode(episode) => (
+          episode.id.to_owned(),
+          episode.name.to_owned(),
+          episode.duration_ms,
+        ),
+      };
+
+      let track_name = if app.liked_song_ids_set.contains(&item_id) {
+        format!("♥ {}", name)
       } else {
-        track_item.name.clone()
+        name
+      };
+
+      let play_bar_text = match track_item {
+        PlayingItem::Track(track) => create_artist_string(&track.artists),
+        PlayingItem::Episode(episode) => format!("{} - {}", episode.name, episode.show.name),
       };
 
       let lines = [Text::styled(
-        create_artist_string(&track_item.artists),
+        play_bar_text,
         Style::default().fg(app.user_config.theme.playbar_text),
       )];
 
@@ -840,10 +858,9 @@ where
           ),
         );
       f.render_widget(artist, chunks[0]);
-      let perc = get_track_progress_percentage(app.song_progress_ms, track_item.duration_ms);
+      let perc = get_track_progress_percentage(app.song_progress_ms, duration_ms);
 
-      let song_progress_label =
-        display_track_progress(app.song_progress_ms, track_item.duration_ms);
+      let song_progress_label = display_track_progress(app.song_progress_ms, duration_ms);
       let song_progress = Gauge::default()
         .block(Block::default().title(""))
         .style(
@@ -1015,7 +1032,13 @@ where
       .map(|top_track| {
         let mut name = String::new();
         if let Some(context) = &app.current_playback_context {
-          if context.item.as_ref().and_then(|item| item.id.as_ref()) == top_track.id.as_ref() {
+          let track_id = match &context.item {
+            Some(PlayingItem::Track(track)) => track.id.to_owned(),
+            Some(PlayingItem::Episode(episode)) => Some(episode.id.to_owned()),
+            _ => None,
+          };
+
+          if track_id == top_track.id {
             name.push_str("▶ ");
           }
         };
@@ -1434,13 +1457,14 @@ fn draw_table<B>(
 {
   let selected_style = get_color(highlight_state, app.user_config.theme).modifier(Modifier::BOLD);
 
-  let track_playing_index = match &app.current_playback_context {
-    Some(ctx) => items.iter().position(|t| match &ctx.item {
-      Some(item) => Some(t.id.to_owned()) == item.id,
-      None => false,
-    }),
-    None => None,
-  };
+  let track_playing_index = app.current_playback_context.to_owned().and_then(|ctx| {
+    ctx.item.and_then(|item| match item {
+      PlayingItem::Track(track) => items
+        .iter()
+        .position(|item| track.id.to_owned().map(|id| id == item.id).unwrap_or(false)),
+      PlayingItem::Episode(_episode) => None,
+    })
+  });
 
   let (title, header) = table_layout;
 


### PR DESCRIPTION
The latest version of [`rspotify`](https://github.com/ramsayleung/rspotify/blob/master/CHANGELOG.md#010-20200701) brings support for podcasts! 

spotify-tui itself still needs to implement searching and playing podcasts, but this PR will enable its development.

This upgrade introduced a number of breaking changes, but thanks to the amazing type system and the Rust compiler, it was fairly easy to just follow the errors for everything to Just Work!