### PR TITLE
Add additional line of help to show that 'w' can be used to save/like an album

### DIFF
--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -104,7 +104,7 @@ pub fn get_help_docs() -> Vec<Vec<&'static str>> {
     ],
     vec!["Delete saved album", "D", "Library -> Albums"],
     vec!["Delete saved playlist", "D", "Playlist"],
-    vec!["Follow an artists/playlist", "w", "Search result"],
+    vec!["Follow an artist/playlist", "w", "Search result"],
     vec!["Play random song in playlist", "S", "Selected Playlist"],
   ]
 }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -105,6 +105,7 @@ pub fn get_help_docs() -> Vec<Vec<&'static str>> {
     vec!["Delete saved album", "D", "Library -> Albums"],
     vec!["Delete saved playlist", "D", "Playlist"],
     vec!["Follow an artist/playlist", "w", "Search result"],
+    vec!["Save (like) album to library", "w", "Search result"],
     vec!["Play random song in playlist", "S", "Selected Playlist"],
   ]
 }


### PR DESCRIPTION
I wanted to save an album to my library as I am used to, but the current help lines didn't make it clear enough that it was even possible from a search result. After trawling through PRs, I found #506, which does exactly what I was looking for, but that change wasn't accompanied by a change in the UIs help section.

I also fixed a small typo where the sentence didn't read properly when plural was used for "artist".