### PR TITLE
Add 'enable_text_emphasis' behavior config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ behavior:
   volume_increment: 10
   # The lower the number the higher the "frames per second". You can decrease this number so that the audio visualisation is smoother but this can be expensive!
   tick_rate_milliseconds: 250
+  # Enable text emphasis (typically italic/bold text styling). Disabling this might be important if the terminal config is otherwise restricted and rendering text escapes interferes with the UI.
+  enable_text_emphasis: true
   # controls whether to show a loading indicator in the top right of the UI whenever communicating with Spotify API
   show_loading_indicator: true
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -872,12 +872,17 @@ where
       let perc = get_track_progress_percentage(app.song_progress_ms, duration_ms);
 
       let song_progress_label = display_track_progress(app.song_progress_ms, duration_ms);
+      let modifier = if app.user_config.behavior.enable_text_emphasis {
+        Modifier::ITALIC | Modifier::BOLD
+      } else {
+        Modifier::empty()
+      };
       let song_progress = Gauge::default()
         .gauge_style(
           Style::default()
             .fg(app.user_config.theme.playbar_progress)
             .bg(app.user_config.theme.playbar_background)
-            .add_modifier(Modifier::ITALIC | Modifier::BOLD),
+            .add_modifier(modifier),
         )
         .percent(perc)
         .label(Span::styled(

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -197,6 +197,7 @@ pub struct BehaviorConfigString {
   pub seek_milliseconds: Option<u32>,
   pub volume_increment: Option<u8>,
   pub tick_rate_milliseconds: Option<u64>,
+  pub enable_text_emphasis: Option<bool>,
   pub show_loading_indicator: Option<bool>,
 }
 
@@ -205,6 +206,7 @@ pub struct BehaviorConfig {
   pub seek_milliseconds: u32,
   pub volume_increment: u8,
   pub tick_rate_milliseconds: u64,
+  pub enable_text_emphasis: bool,
   pub show_loading_indicator: bool,
 }
 
@@ -254,6 +256,7 @@ impl UserConfig {
         seek_milliseconds: 5 * 1000,
         volume_increment: 10,
         tick_rate_milliseconds: 250,
+        enable_text_emphasis: true,
         show_loading_indicator: true,
       },
       path_to_config: None,
@@ -368,6 +371,10 @@ impl UserConfig {
       } else {
         self.behavior.tick_rate_milliseconds = tick_rate;
       }
+    }
+
+    if let Some(text_emphasis) = behavior_config.enable_text_emphasis {
+      self.behavior.enable_text_emphasis = text_emphasis;
     }
 
     if let Some(loading_indicator) = behavior_config.show_loading_indicator {


### PR DESCRIPTION
As mentioned in Issue #568, some users' terminals can have escaping issues with text emphasis.
This pull request introduces a new field named `enable_text_emphasis` to `BehaviorConfig`.

`BehaviorConfig` seemed better suited as a home for this bit than `Theme`, and required less work. ;-)

Open to simpler/more sustainable ways to make this change, of course! First time contributer here.