### PR TITLE
Don't add analysis view to stack if already in it.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -891,9 +891,11 @@ impl App {
     {
       match item {
         PlayingItem::Track(track) => {
-          let uri = track.uri.clone();
-          self.dispatch(IoEvent::GetAudioAnalysis(uri));
-          self.push_navigation_stack(RouteId::Analysis, ActiveBlock::Analysis);
+          if self.get_current_route().id != RouteId::Analysis {
+            let uri = track.uri.clone();
+            self.dispatch(IoEvent::GetAudioAnalysis(uri));
+            self.push_navigation_stack(RouteId::Analysis, ActiveBlock::Analysis);
+          }
         }
         PlayingItem::Episode(_epidose) => {}
       }


### PR DESCRIPTION
Before this commit, if a user pressed `v` multiple times, they would
have to press `q` the same number of times to get to the previous view.

This commit makes it so that an analysis view entry is only pushed into
the navigation stack if the current view isn't an analysis one.