### PR TITLE
Add user-configurable header styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ theme:
   playbar_text: White # artist name in player pane
   selected: LightCyan # a) selected pane border, b) hovered item in list, & c) track title in player
   text: "255, 255, 255" # text in panes
+  header: White  # header text in panes (e.g. 'Title', 'Artist', etc.)
 
 behavior:
   seek_milliseconds: 5000

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1573,6 +1573,7 @@ fn draw_table<B>(
         .border_style(get_color(highlight_state, app.user_config.theme)),
     )
     .style(Style::default().fg(app.user_config.theme.text))
+    .header_style(Style::default().fg(app.user_config.theme.header))
     .widths(&widths);
   f.render_widget(table, layout_chunk);
 }

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -26,6 +26,7 @@ pub struct UserTheme {
   pub playbar_text: Option<String>,
   pub selected: Option<String>,
   pub text: Option<String>,
+  pub header: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -45,6 +46,7 @@ pub struct Theme {
   pub playbar_text: Color,
   pub selected: Color,
   pub text: Color,
+  pub header: Color,
 }
 
 impl Default for Theme {
@@ -65,6 +67,7 @@ impl Default for Theme {
       playbar_text: Color::White,
       selected: Color::LightCyan,
       text: Color::White,
+      header: Color::White,
     }
   }
 }
@@ -344,6 +347,7 @@ impl UserConfig {
     to_theme_item!(playbar_text);
     to_theme_item!(selected);
     to_theme_item!(text);
+    to_theme_item!(header);
     Ok(())
   }
 


### PR DESCRIPTION
- Header text in panes is not affected by the color value set for 'text' in config.yml
    - Results in headers always written in white, which causes clash with non-white themes
- Add new theme 'header' setting and use it to style the header text

![pre-fix](https://user-images.githubusercontent.com/11470871/93731669-f00e2300-fb82-11ea-86c2-63a8c0deafe8.png)

![post-fix](https://user-images.githubusercontent.com/11470871/93731673-f3a1aa00-fb82-11ea-8cd6-37462d8d5ae5.png)

