### PR TITLE
Updated README with correct brew command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The binary executable is `spt`.
 For both macOS and Linux
 
 ```bash
-brew install Rigellute/tap/spotify-tui
+brew install spotify-tui
 ```
 
 To update, run


### PR DESCRIPTION
spotify-tui is available as an official tap
Trying to install with the current instructions gives an error
`Error: No available formula or cask with the name "Rigellute/tap/spotify-tui"`