### PR TITLE
Implement next/previous page behavior for the Artists table

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -676,6 +676,52 @@ impl App {
     ));
   }
 
+  pub fn set_saved_artists_to_table(&mut self, saved_artists_page: &CursorBasedPage<FullArtist>) {
+    self.dispatch(IoEvent::SetArtistsToTable(
+      saved_artists_page
+        .items
+        .clone()
+        .into_iter()
+        .collect::<Vec<FullArtist>>(),
+    ))
+  }
+
+  pub fn get_current_user_saved_artists_next(&mut self) {
+    match self
+      .library
+      .saved_artists
+      .get_results(Some(self.library.saved_artists.index + 1))
+      .cloned()
+    {
+      Some(saved_artists) => {
+        self.set_saved_artists_to_table(&saved_artists);
+        self.library.saved_artists.index += 1
+      }
+      None => {
+        if let Some(saved_artists) = &self.library.saved_artists.clone().get_results(None) {
+          match saved_artists.items.last() {
+            Some(last_artist) => {
+              self.dispatch(IoEvent::GetFollowedArtists(Some(last_artist.id.clone())));
+            }
+            None => {
+              return;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  pub fn get_current_user_saved_artists_previous(&mut self) {
+    if self.library.saved_artists.index > 0 {
+      self.library.saved_artists.index -= 1;
+    }
+
+    if let Some(saved_artists) = &self.library.saved_artists.get_results(None).cloned() {
+      self.set_saved_artists_to_table(&saved_artists);
+    }
+  }
+
   pub fn get_current_user_saved_tracks_next(&mut self) {
     // Before fetching the next tracks, check if we have already fetched them
     match self

--- a/src/handlers/artists.rs
+++ b/src/handlers/artists.rs
@@ -72,6 +72,8 @@ pub fn handler(key: Key, app: &mut App) {
         app.get_recommendations_for_seed(artist_id_list, None, None);
       }
     }
+    k if k == app.user_config.keys.next_page => app.get_current_user_saved_artists_next(),
+    k if k == app.user_config.keys.previous_page => app.get_current_user_saved_artists_previous(),
     _ => {}
   }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -8,6 +8,7 @@ use rspotify::{
   client::Spotify,
   model::{
     album::SimplifiedAlbum,
+    artist::FullArtist,
     offset::for_position,
     page::Page,
     playlist::{PlaylistTrack, SimplifiedPlaylist},
@@ -71,6 +72,7 @@ pub enum IoEvent {
   GetRecommendationsForTrackId(String, Option<Country>),
   GetRecentlyPlayed,
   GetFollowedArtists(Option<String>),
+  SetArtistsToTable(Vec<FullArtist>),
   UserArtistFollowCheck(Vec<String>),
   GetAlbum(String),
   SetDeviceIdInConfig(String),
@@ -246,6 +248,9 @@ impl<'a> Network<'a> {
       IoEvent::GetFollowedArtists(after) => {
         self.get_followed_artists(after).await;
       }
+      IoEvent::SetArtistsToTable(full_artists) => {
+        self.set_artists_to_table(full_artists).await;
+      }
       IoEvent::UserArtistFollowCheck(artist_ids) => {
         self.user_artist_check_follow(artist_ids).await;
       }
@@ -402,6 +407,11 @@ impl<'a> Network<'a> {
         .filter_map(|item| item.id)
         .collect::<Vec<String>>(),
     ));
+  }
+
+  async fn set_artists_to_table(&mut self, artists: Vec<FullArtist>) {
+    let mut app = self.app.lock().await;
+    app.artists = artists;
   }
 
   async fn get_made_for_you_playlist_tracks(


### PR DESCRIPTION
This closes #603 which I just filed.

I'm new to Rust, so any feedback is welcome!

Lastly, I think pagination behavior may be in want of a re-work. It seems like we're missing pagination for a bunch of views and I imagine their implementations will all share quite a bit in common. I didn't take on the larger task of a big refactor but it may be something we should consider.

Here's a demo gif (ignore color issues, it's my first time trying to use `terminalizer` to record my terminal).
![artists-pagination-demo](https://user-images.githubusercontent.com/10730394/95007102-cc62c800-05d9-11eb-9c18-2ef733ad128b.gif)
