### PR TITLE
Update the saved albums cache set when getting an artist

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -785,14 +785,16 @@ impl<'a> Network<'a> {
 
     if let Ok((albums, top_tracks, related_artist)) = try_join!(albums, top_tracks, related_artist)
     {
-      let album_ids = albums
-        .items
-        .iter()
-        .filter_map(|item| item.id.to_owned())
-        .collect();
-      self.current_user_saved_albums_contains(album_ids).await;
-
       let mut app = self.app.lock().await;
+
+      app.dispatch(IoEvent::CurrentUserSavedAlbumsContains(
+        albums
+          .items
+          .iter()
+          .filter_map(|item| item.id.to_owned())
+          .collect(),
+      ));
+
       app.artist = Some(Artist {
         artist_name,
         albums,


### PR DESCRIPTION
This closes #611 which I just filed.

Check out the issue for some screenshots. This PR effectively makes the second screenshot in that issue description correct, in that it recognizes the saved albums on that artist.

As mentioned in that issue too, we seemingly _do not_ update the saved tracks set when searching, so I omitted adding that into this patch, but it's easy enough to extend this patch to apply to tracks and make things consistent.