### PR TITLE
Support searching by Spotify share URLs and URIs analogously to the desktop client

### DIFF
--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -164,10 +164,10 @@ fn attempt_process_uri(app: &mut App, input: &str, base: &str, sep: &str) -> boo
     return true;
   }
 
-  let (podcast_id, matched) = spotify_resource_id(trimmed_uri, "podcast");
+  let (show_id, matched) = spotify_resource_id(trimmed_uri, "show");
   if matched {
-    eprintln!("matched podcast, open for id: {}!", podcast_id);
-    // TODO(may): Dispatch some kind of GetPodcast event, analogous to the ones above?
+    eprintln!("matched show, open for id: {}!", show_id);
+    app.dispatch(IoEvent::GetShowEpisodes(show_id));
     return true;
   }
 

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -117,10 +117,6 @@ fn process_input(app: &mut App, input: String) {
 fn spotify_resource_id(base: &str, uri: &str, sep: &str, resource_type: &str) -> (String, bool) {
   let uri_prefix = format!("{}{}{}", base, resource_type, sep);
   let id_string = uri.trim_start_matches(&uri_prefix);
-  eprintln!(
-    "uri prefix found: {}, for uri: {}, id_string: {}",
-    uri_prefix, uri, id_string
-  );
   // If the lengths aren't equal, we must have found a match.
   (id_string.to_string(), id_string.len() != uri.len())
 }
@@ -142,21 +138,18 @@ fn attempt_process_uri(app: &mut App, input: &str, base: &str, sep: &str) -> boo
 
   let (track_id, matched) = spotify_resource_id(base, input, sep, "track");
   if matched {
-    eprintln!("matched track, open for id: {}!", track_id);
     app.dispatch(IoEvent::GetAlbumForTrack(track_id));
     return true;
   }
 
   let (playlist_id, matched) = spotify_resource_id(base, input, sep, "playlist");
   if matched {
-    eprintln!("matched playlist, open for id: {}!", playlist_id);
     app.dispatch(IoEvent::GetPlaylistTracks(playlist_id, 0));
     return true;
   }
 
   let (show_id, matched) = spotify_resource_id(base, input, sep, "show");
   if matched {
-    eprintln!("matched show, open for id: {}!", show_id);
     app.dispatch(IoEvent::GetShowEpisodes(show_id));
     return true;
   }

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -123,7 +123,7 @@ fn spotify_resource_id(base: &str, uri: &str, sep: &str, resource_type: &str) ->
   let id_string = id_string_with_query_params[0..query_idx].to_string();
   // If the lengths aren't equal, we must have found a match.
   let matched = id_string_with_query_params.len() != uri.len() && id_string.len() != uri.len();
-  (id_string.to_string(), matched)
+  (id_string, matched)
 }
 
 // Returns true if the input was successfully processed as a Spotify URI.

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -100,6 +100,9 @@ fn process_input(app: &mut App, input: String) {
     return;
   }
 
+  // On searching for a track, clear the playlist selection
+  app.selected_playlist_index = Some(0);
+
   if attempt_process_uri(app, &input, "https://open.spotify.com/", "/")
     || attempt_process_uri(app, &input, "spotify:", ":")
   {
@@ -108,9 +111,6 @@ fn process_input(app: &mut App, input: String) {
 
   // Default fallback behavior: treat the input as a raw search phrase.
   app.dispatch(IoEvent::GetSearchResults(input, app.get_user_country()));
-
-  // On searching for a track, clear the playlist selection
-  app.selected_playlist_index = Some(0);
   app.push_navigation_stack(RouteId::Search, ActiveBlock::SearchResultBlock);
 }
 

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -128,17 +128,14 @@ fn spotify_resource_id(base: &str, uri: &str, sep: &str, resource_type: &str) ->
 
 // Returns true if the input was successfully processed as a Spotify URI.
 fn attempt_process_uri(app: &mut App, input: &str, base: &str, sep: &str) -> bool {
-  eprintln!("ATTEMPTING");
   let (album_id, matched) = spotify_resource_id(base, input, sep, "album");
   if matched {
-    eprintln!("ALBUM");
     app.dispatch(IoEvent::GetAlbum(album_id));
     return true;
   }
 
   let (artist_id, matched) = spotify_resource_id(base, input, sep, "artist");
   if matched {
-    eprintln!("ARTIST");
     app.get_artist(artist_id, "".to_string());
     app.push_navigation_stack(RouteId::Artist, ActiveBlock::ArtistBlock);
     return true;
@@ -146,23 +143,18 @@ fn attempt_process_uri(app: &mut App, input: &str, base: &str, sep: &str) -> boo
 
   let (track_id, matched) = spotify_resource_id(base, input, sep, "track");
   if matched {
-    eprintln!("TRACK");
     app.dispatch(IoEvent::GetAlbumForTrack(track_id));
     return true;
   }
 
   let (playlist_id, matched) = spotify_resource_id(base, input, sep, "playlist");
   if matched {
-    eprintln!("GOTEM WITH ID: {}", playlist_id);
     app.dispatch(IoEvent::GetPlaylistTracks(playlist_id, 0));
     return true;
-  } else {
-    eprintln!("DID NOT MATCH");
   }
 
   let (show_id, matched) = spotify_resource_id(base, input, sep, "show");
   if matched {
-    eprintln!("show");
     app.dispatch(IoEvent::GetShowEpisodes(show_id));
     return true;
   }

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -151,9 +151,7 @@ fn attempt_process_uri(app: &mut App, input: &str, base: &str, sep: &str) -> boo
   let (track_id, matched) = spotify_resource_id(trimmed_uri, "track");
   if matched {
     eprintln!("matched track, open for id: {}!", track_id);
-    // TODO(may): Implement an IoEvent for GetTrack that effectively gets the track's parent
-    // album & subsequently dispatches a GetAlbum event, or, perhaps does the same logic of
-    // GetAlbum and then focuses on the track in that album?
+    app.dispatch(IoEvent::GetAlbumForTrack(track_id));
     return true;
   }
 

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -412,27 +412,55 @@ mod tests {
       assert_eq!(parsed.0, expected_id);
     }
 
-    #[test]
-    fn artists() {
-      let expected_artist_id = "2ye2Wgw4gimLv2eAKyk1NB";
+    fn run_test_for_id_and_resource_type(id: &str, resource_type: &str) {
       check_uri_parse(
-        expected_artist_id,
+        id,
         spotify_resource_id(
           URI_BASE,
-          "spotify:artist:2ye2Wgw4gimLv2eAKyk1NB",
+          &format!("spotify:{}:{}", resource_type, id),
           ":",
-          "artist",
+          resource_type,
         ),
       );
       check_uri_parse(
-        expected_artist_id,
+        id,
         spotify_resource_id(
           URL_BASE,
-          "https://open.spotify.com/artist/2ye2Wgw4gimLv2eAKyk1NB",
+          &format!("https://open.spotify.com/{}/{}", resource_type, id),
           "/",
-          "artist",
+          resource_type,
         ),
       )
+    }
+
+    #[test]
+    fn artist() {
+      let expected_artist_id = "2ye2Wgw4gimLv2eAKyk1NB";
+      run_test_for_id_and_resource_type(expected_artist_id, "artist");
+    }
+
+    #[test]
+    fn album() {
+      let expected_album_id = "5gzLOflH95LkKYE6XSXE9k";
+      run_test_for_id_and_resource_type(expected_album_id, "album");
+    }
+
+    #[test]
+    fn playlist() {
+      let expected_playlist_id = "1cJ6lPBYj2fscs0kqBHsVV";
+      run_test_for_id_and_resource_type(expected_playlist_id, "playlist");
+    }
+
+    #[test]
+    fn show() {
+      let expected_show_id = "3aNsrV6lkzmcU1w8u8kA7N";
+      run_test_for_id_and_resource_type(expected_show_id, "show");
+    }
+
+    #[test]
+    fn track() {
+      let expected_track_id = "10igKaIKsSB6ZnWxPxPvKO";
+      run_test_for_id_and_resource_type(expected_track_id, "track");
     }
   }
 }

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -141,6 +141,32 @@ fn attempt_process_uri(app: &mut App, input: &str, base: &str, sep: &str) -> boo
     return true;
   }
 
+  let track_uri_prefix = format!("track{}", sep);
+  if trimmed_uri.starts_with(&track_uri_prefix) {
+    let track_id = trimmed_uri.trim_start_matches(&track_uri_prefix);
+    eprintln!("matched track, open for id: {}!", track_id);
+    // TODO(may): Implement an IoEvent for GetTrack that effectively gets the track's parent
+    // album & subsequently dispatches a GetAlbum event, or, perhaps does the same logic of
+    // GetAlbum and then focuses on the track in that album?
+    return true;
+  }
+
+  let playlist_uri_prefix = format!("playlist{}", sep);
+  if trimmed_uri.starts_with(&playlist_uri_prefix) {
+    let playlist_id = trimmed_uri.trim_start_matches(&playlist_uri_prefix);
+    eprintln!("matched playlist, open for id: {}!", playlist_id);
+    // TODO(may): Dispatch a GetPlaylistTracks() on the playlist idea and offset 0?
+    return true;
+  }
+
+  let podcast_uri_prefix = format!("podcast{}", sep);
+  if trimmed_uri.starts_with(&podcast_uri_prefix) {
+    let podcast_id = trimmed_uri.trim_start_matches(&podcast_uri_prefix);
+    eprintln!("matched podcast, open for id: {}!", podcast_id);
+    // TODO(may): Dispatch some kind of GetPodcast event, analogous to the ones above?
+    return true;
+  }
+
   false
 }
 

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -462,5 +462,20 @@ mod tests {
       let expected_track_id = "10igKaIKsSB6ZnWxPxPvKO";
       run_test_for_id_and_resource_type(expected_track_id, "track");
     }
+
+    #[test]
+    fn invalid_format_doesnt_match() {
+      let swapped = "show:spotify:3aNsrV6lkzmcU1w8u8kA7N";
+      let totally_wrong = "hehe-haha-3aNsrV6lkzmcU1w8u8kA7N";
+      let random = "random string";
+      let (_, matched) = spotify_resource_id(URI_BASE, swapped, ":", "track");
+      assert_eq!(matched, false);
+      let (_, matched) = spotify_resource_id(URI_BASE, totally_wrong, ":", "track");
+      assert_eq!(matched, false);
+      let (_, matched) = spotify_resource_id(URL_BASE, totally_wrong, "/", "track");
+      assert_eq!(matched, false);
+      let (_, matched) = spotify_resource_id(URL_BASE, random, "/", "track");
+      assert_eq!(matched, false);
+    }
   }
 }

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -119,7 +119,7 @@ fn spotify_resource_id(base: &str, uri: &str, sep: &str, resource_type: &str) ->
   let id_string_with_query_params = uri.trim_start_matches(&uri_prefix);
   let query_idx = id_string_with_query_params
     .find('?')
-    .unwrap_or(id_string_with_query_params.len());
+    .unwrap_or_else(|| id_string_with_query_params.len());
   let id_string = id_string_with_query_params[0..query_idx].to_string();
   // If the lengths aren't equal, we must have found a match.
   let matched = id_string_with_query_params.len() != uri.len() && id_string.len() != uri.len();

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -160,7 +160,7 @@ fn attempt_process_uri(app: &mut App, input: &str, base: &str, sep: &str) -> boo
   let (playlist_id, matched) = spotify_resource_id(trimmed_uri, "playlist");
   if matched {
     eprintln!("matched playlist, open for id: {}!", playlist_id);
-    // TODO(may): Dispatch a GetPlaylistTracks() on the playlist idea and offset 0?
+    app.dispatch(IoEvent::GetPlaylistTracks(playlist_id, 0));
     return true;
   }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -1262,12 +1262,12 @@ impl<'a> Network<'a> {
   async fn get_album_for_track(&mut self, track_id: String) {
     match self.spotify.track(&track_id).await {
       Ok(track) => {
-        if track.album.id.is_none() {
-          // It is unclear when this is possible, but perhaps a track can be album-less. If so,
-          // there isn't much to do here anyways, since we're looking for the parent album.
-          return;
-        }
-        let album_id = track.album.id.unwrap(); // This unwrap is safe due to the above check.
+        // It is unclear when the id can ever be None, but perhaps a track can be album-less. If
+        // so, there isn't much to do here anyways, since we're looking for the parent album.
+        let album_id = match track.album.id {
+          Some(id) => id,
+          None => return,
+        };
 
         if let Ok(album) = self.spotify.album(&album_id).await {
           // The way we map to the UI is zero-indexed, but Spotify is 1-indexed.

--- a/src/network.rs
+++ b/src/network.rs
@@ -381,9 +381,7 @@ impl<'a> Network<'a> {
 
       let mut app = self.app.lock().await;
       app.playlist_tracks = Some(playlist_tracks);
-      if app.get_current_route().id != RouteId::TrackTable {
-        app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
-      };
+      app.push_navigation_stack(RouteId::TrackTable, ActiveBlock::TrackTable);
     };
   }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -1280,7 +1280,8 @@ impl<'a> Network<'a> {
 
           let mut app = self.app.lock().await;
 
-          app.selected_album_full = Some(selected_album);
+          app.selected_album_full = Some(selected_album.clone());
+          app.saved_album_tracks_index = selected_album.selected_index;
           app.album_table_context = AlbumTableContext::Full;
           app.push_navigation_stack(RouteId::AlbumTracks, ActiveBlock::AlbumTracks);
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -657,7 +657,7 @@ where
           selected_album.album.name,
           create_artist_string(&selected_album.album.artists)
         ),
-        selected_index: selected_album.selected_index,
+        selected_index: app.saved_album_tracks_index,
       }),
       None => None,
     },

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -657,7 +657,7 @@ where
           selected_album.album.name,
           create_artist_string(&selected_album.album.artists)
         ),
-        selected_index: app.saved_album_tracks_index,
+        selected_index: selected_album.selected_index,
       }),
       None => None,
     },


### PR DESCRIPTION
This closes #41.

To be more precise, this actually adds significantly more functionality than what is requested in #41. In particular, this PR adds support for opening:

- Tracks (will open its containing album and move the selection to the searched track)
- Albums
- Artists
- Playlists
- Shows/Podcasts

Via either their Spotify share URL, e.g.:

```
https://open.spotify.com/album/6QdCohkHKNTVoaSx1ZzitH?si=vJQhe4H5RwiGcDf4xr9DuQ
```

Or their Spotify URI:
```
spotify:album:6QdCohkHKNTVoaSx1ZzitH
```

On the official desktop client, searching with either of these leads you to the Metallica album, [Metallica](https://open.spotify.com/album/6QdCohkHKNTVoaSx1ZzitH).

If the given input string fails to match either URI format, it will default to the original raw phrase search.

Here are some representative screenshots:
![image](https://user-images.githubusercontent.com/10730394/96223947-c3201680-0f5c-11eb-83c1-9828ab287cc9.png)
Press enter...
![image](https://user-images.githubusercontent.com/10730394/96223979-cca97e80-0f5c-11eb-9f61-8aec05580218.png)
**Note** The highlighting/focusing of the track is automatically done.

There were some decisions I made in this PR that may be worth discussing. For those, I've let a comment.