### PR TITLE
Implement Podcasts Library page

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ use rspotify::{
     page::{CursorBasedPage, Page},
     playing::PlayHistory,
     playlist::{PlaylistTrack, SimplifiedPlaylist},
-    show::{SimplifiedEpisode, SimplifiedShow, Show},
+    show::{Show, SimplifiedEpisode, SimplifiedShow},
     track::{FullTrack, SavedTrack, SimplifiedTrack},
     user::PrivateUser,
     PlayingItem,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1007,8 +1007,9 @@ impl App {
       ActiveBlock::SearchResultBlock => {
         if let Some(shows) = &self.search_results.shows {
           if let Some(selected_index) = self.search_results.selected_shows_index {
-            let show_id = shows.items[selected_index].id.to_owned();
-            self.dispatch(IoEvent::CurrentUserSavedShowAdd(show_id));
+            if let Some(show_id) = shows.items.get(selected_index).map(|item| item.id.clone()) {
+              self.dispatch(IoEvent::CurrentUserSavedShowAdd(show_id));
+            }
           }
         }
       }

--- a/src/handlers/empty.rs
+++ b/src/handlers/empty.rs
@@ -19,6 +19,8 @@ pub fn handler(key: Key, app: &mut App) {
       | ActiveBlock::AlbumList
       | ActiveBlock::AlbumTracks
       | ActiveBlock::Artists
+      | ActiveBlock::Podcasts
+      | ActiveBlock::EpisodeTable
       | ActiveBlock::Home
       | ActiveBlock::MadeForYou
       | ActiveBlock::MyPlaylists
@@ -42,6 +44,8 @@ pub fn handler(key: Key, app: &mut App) {
       | ActiveBlock::AlbumList
       | ActiveBlock::AlbumTracks
       | ActiveBlock::Artists
+      | ActiveBlock::Podcasts
+      | ActiveBlock::EpisodeTable
       | ActiveBlock::Home
       | ActiveBlock::MadeForYou
       | ActiveBlock::RecentlyPlayed

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -62,6 +62,7 @@ pub fn handler(key: Key, app: &mut App) {
       }
       // Podcasts,
       5 => {
+        app.dispatch(IoEvent::GetSavedShows(None));
         app.push_navigation_stack(RouteId::Podcasts, ActiveBlock::Podcasts);
       }
       // This is required because Rust can't tell if this pattern in exhaustive

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -62,7 +62,7 @@ pub fn handler(key: Key, app: &mut App) {
       }
       // Podcasts,
       5 => {
-        app.dispatch(IoEvent::GetSavedShows(None));
+        app.dispatch(IoEvent::GetCurrentUserSavedShows(None));
         app.push_navigation_stack(RouteId::Podcasts, ActiveBlock::Podcasts);
       }
       // This is required because Rust can't tell if this pattern in exhaustive

--- a/src/handlers/podcasts.rs
+++ b/src/handlers/podcasts.rs
@@ -11,14 +11,14 @@ pub fn handler(key: Key, app: &mut App) {
     k if common_key_events::down_event(k) => {
       if let Some(shows) = &mut app.library.saved_shows.get_results(None) {
         let next_index =
-            common_key_events::on_down_press_handler(&shows.items, Some(app.shows_list_index));
+          common_key_events::on_down_press_handler(&shows.items, Some(app.shows_list_index));
         app.shows_list_index = next_index;
       }
     }
     k if common_key_events::up_event(k) => {
       if let Some(shows) = &mut app.library.saved_shows.get_results(None) {
         let next_index =
-            common_key_events::on_up_press_handler(&shows.items, Some(app.shows_list_index));
+          common_key_events::on_up_press_handler(&shows.items, Some(app.shows_list_index));
         app.shows_list_index = next_index;
       }
     }

--- a/src/handlers/podcasts.rs
+++ b/src/handlers/podcasts.rs
@@ -1,9 +1,57 @@
-use super::{super::app::App, common_key_events};
-use crate::event::Key;
+use super::common_key_events;
+use crate::{
+  app::{ActiveBlock, App},
+  event::Key,
+  network::IoEvent,
+};
 
 pub fn handler(key: Key, app: &mut App) {
   match key {
     k if common_key_events::left_event(k) => common_key_events::handle_left_event(app),
+    k if common_key_events::down_event(k) => {
+      if let Some(shows) = &mut app.library.saved_shows.get_results(None) {
+        let next_index =
+            common_key_events::on_down_press_handler(&shows.items, Some(app.shows_list_index));
+        app.shows_list_index = next_index;
+      }
+    }
+    k if common_key_events::up_event(k) => {
+      if let Some(shows) = &mut app.library.saved_shows.get_results(None) {
+        let next_index =
+            common_key_events::on_up_press_handler(&shows.items, Some(app.shows_list_index));
+        app.shows_list_index = next_index;
+      }
+    }
+    k if common_key_events::high_event(k) => {
+      if let Some(_shows) = app.library.saved_shows.get_results(None) {
+        let next_index = common_key_events::on_high_press_handler();
+        app.shows_list_index = next_index;
+      }
+    }
+    k if common_key_events::middle_event(k) => {
+      if let Some(shows) = app.library.saved_shows.get_results(None) {
+        let next_index = common_key_events::on_middle_press_handler(&shows.items);
+        app.shows_list_index = next_index;
+      }
+    }
+    k if common_key_events::low_event(k) => {
+      if let Some(shows) = app.library.saved_shows.get_results(None) {
+        let next_index = common_key_events::on_low_press_handler(&shows.items);
+        app.shows_list_index = next_index;
+      }
+    }
+    Key::Enter => {
+      if let Some(shows) = app.library.saved_shows.get_results(None) {
+        if let Some(selected_show) = shows.items.get(app.shows_list_index) {
+          // Go to show tracks table
+          let show_id = selected_show.show.id.to_owned();
+          app.dispatch(IoEvent::GetShowEpisodes(show_id));
+        };
+      }
+    }
+    k if k == app.user_config.keys.next_page => app.get_current_user_saved_shows_next(),
+    k if k == app.user_config.keys.previous_page => app.get_current_user_saved_shows_previous(),
+    Key::Char('D') => app.user_unfollow_show(ActiveBlock::Podcasts),
     _ => {}
   }
 }

--- a/src/handlers/search_results.rs
+++ b/src/handlers/search_results.rs
@@ -550,7 +550,7 @@ pub fn handler(key: Key, app: &mut App) {
           app.push_navigation_stack(route, ActiveBlock::Dialog(DialogContext::PlaylistSearch));
         }
       }
-      SearchResultBlock::ShowSearch => app.user_unfollow_show(),
+      SearchResultBlock::ShowSearch => app.user_unfollow_show(ActiveBlock::SearchResultBlock),
       SearchResultBlock::Empty => {}
     },
     Key::Char('r') => handle_recommended_tracks(app),

--- a/src/handlers/search_results.rs
+++ b/src/handlers/search_results.rs
@@ -526,9 +526,7 @@ pub fn handler(key: Key, app: &mut App) {
       SearchResultBlock::PlaylistSearch => {
         app.user_follow_playlist();
       }
-      SearchResultBlock::ShowSearch => {
-        app.user_follow_show();
-      }
+      SearchResultBlock::ShowSearch => app.user_follow_show(ActiveBlock::SearchResultBlock),
       SearchResultBlock::Empty => {}
     },
     Key::Char('D') => match app.search_results.selected_block {

--- a/src/network.rs
+++ b/src/network.rs
@@ -1120,11 +1120,7 @@ impl<'a> Network<'a> {
   }
 
   async fn current_user_saved_show_add(&mut self, show_id: String) {
-    match self
-        .spotify
-        .save_shows(vec![show_id])
-        .await
-    {
+    match self.spotify.save_shows(vec![show_id]).await {
       Ok(_) => {
         self.get_saved_shows(None).await;
       }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -30,6 +30,7 @@ pub enum TableId {
   Album,
   AlbumList,
   Artist,
+  Podcast,
   Song,
   RecentlyPlayed,
   MadeForYou,
@@ -258,7 +259,7 @@ where
       draw_artist_table(f, app, chunks[1]);
     }
     RouteId::Podcasts => {
-      draw_not_implemented_yet(f, app, chunks[1], ActiveBlock::Podcasts, "Podcasts");
+      draw_podcast_table(f, app, chunks[1]);
     }
     RouteId::Recommendations => {
       draw_recommendations_table(f, app, chunks[1]);
@@ -568,6 +569,58 @@ where
     app.artists_list_index,
     highlight_state,
   )
+}
+
+pub fn draw_podcast_table<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
+  where
+      B: Backend,
+{
+  let header = TableHeader {
+    id: TableId::Podcast,
+    items: vec![
+      TableHeaderItem {
+        text: "Name",
+        width: get_percentage_width(layout_chunk.width, 2.0 / 5.0),
+        ..Default::default()
+      },
+      TableHeaderItem {
+        text: "Publisher(s)",
+        width: get_percentage_width(layout_chunk.width, 2.0 / 5.0),
+        ..Default::default()
+      },
+    ],
+  };
+
+  let current_route = app.get_current_route();
+
+  let highlight_state = (
+    current_route.active_block == ActiveBlock::Podcasts,
+    current_route.hovered_block == ActiveBlock::Podcasts,
+  );
+
+  if let Some(saved_shows) = app.library.saved_shows.get_results(None) {
+    let items = saved_shows
+      .items
+      .iter()
+      .map(|show_page| TableItem {
+        id: show_page.show.id.to_owned(),
+        format: vec![
+          show_page.show.name.to_owned(),
+          show_page.show.publisher.to_owned(),
+        ],
+      })
+      .collect::<Vec<TableItem>>();
+
+    draw_table(
+      f,
+      app,
+      layout_chunk,
+      ("Podcasts", &header),
+      &items,
+      app.shows_list_index,
+      highlight_state,
+    )
+  };
 }
 
 pub fn draw_album_table<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -511,7 +511,14 @@ where
       Some(podcasts) => podcasts
         .items
         .iter()
-        .map(|item| format!("{:} - {}", item.name, item.publisher))
+        .map(|item| {
+          let mut show_name = String::new();
+          if app.saved_show_ids_set.contains(&item.id.to_owned()) {
+            show_name.push_str("♥ ");
+          }
+          show_name.push_str(&format!("{:} - {}", item.name, item.publisher));
+          show_name
+        })
         .collect(),
       None => vec![],
     };

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1167,37 +1167,6 @@ where
   f.render_widget(bottom_text, chunks[1]);
 }
 
-// fn draw_not_implemented_yet<B>(
-//   f: &mut Frame<B>,
-//   app: &App,
-//   layout_chunk: Rect,
-//   block: ActiveBlock,
-//   title: &str,
-// ) where
-//   B: Backend,
-// {
-//   let current_route = app.get_current_route();
-//   let highlight_state = (
-//     current_route.active_block == block,
-//     current_route.hovered_block == block,
-//   );
-//   let display_block = Block::default()
-//     .title(Span::styled(
-//       title,
-//       get_color(highlight_state, app.user_config.theme),
-//     ))
-//     .borders(Borders::ALL)
-//     .border_style(get_color(highlight_state, app.user_config.theme));
-//
-//   let text = Text::from("Not implemented yet!");
-//
-//   let not_implemented = Paragraph::new(text)
-//     .style(Style::default().fg(app.user_config.theme.text))
-//     .block(display_block)
-//     .wrap(Wrap { trim: true });
-//   f.render_widget(not_implemented, layout_chunk);
-// }
-
 fn draw_artist_albums<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
 where
   B: Backend,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -514,7 +514,7 @@ where
         .map(|item| {
           let mut show_name = String::new();
           if app.saved_show_ids_set.contains(&item.id.to_owned()) {
-            show_name.push_str("♥ ");
+            show_name.push_str(&app.user_config.padded_liked_icon());
           }
           show_name.push_str(&format!("{:} - {}", item.name, item.publisher));
           show_name

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1164,36 +1164,36 @@ where
   f.render_widget(bottom_text, chunks[1]);
 }
 
-fn draw_not_implemented_yet<B>(
-  f: &mut Frame<B>,
-  app: &App,
-  layout_chunk: Rect,
-  block: ActiveBlock,
-  title: &str,
-) where
-  B: Backend,
-{
-  let current_route = app.get_current_route();
-  let highlight_state = (
-    current_route.active_block == block,
-    current_route.hovered_block == block,
-  );
-  let display_block = Block::default()
-    .title(Span::styled(
-      title,
-      get_color(highlight_state, app.user_config.theme),
-    ))
-    .borders(Borders::ALL)
-    .border_style(get_color(highlight_state, app.user_config.theme));
-
-  let text = Text::from("Not implemented yet!");
-
-  let not_implemented = Paragraph::new(text)
-    .style(Style::default().fg(app.user_config.theme.text))
-    .block(display_block)
-    .wrap(Wrap { trim: true });
-  f.render_widget(not_implemented, layout_chunk);
-}
+// fn draw_not_implemented_yet<B>(
+//   f: &mut Frame<B>,
+//   app: &App,
+//   layout_chunk: Rect,
+//   block: ActiveBlock,
+//   title: &str,
+// ) where
+//   B: Backend,
+// {
+//   let current_route = app.get_current_route();
+//   let highlight_state = (
+//     current_route.active_block == block,
+//     current_route.hovered_block == block,
+//   );
+//   let display_block = Block::default()
+//     .title(Span::styled(
+//       title,
+//       get_color(highlight_state, app.user_config.theme),
+//     ))
+//     .borders(Borders::ALL)
+//     .border_style(get_color(highlight_state, app.user_config.theme));
+//
+//   let text = Text::from("Not implemented yet!");
+//
+//   let not_implemented = Paragraph::new(text)
+//     .style(Style::default().fg(app.user_config.theme.text))
+//     .block(display_block)
+//     .wrap(Wrap { trim: true });
+//   f.render_widget(not_implemented, layout_chunk);
+// }
 
 fn draw_artist_albums<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
 where

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -572,8 +572,8 @@ where
 }
 
 pub fn draw_podcast_table<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
-  where
-      B: Backend,
+where
+  B: Backend,
 {
   let header = TableHeader {
     id: TableId::Podcast,


### PR DESCRIPTION
Implemented:
- Podcasts page shows list of user's saved podcasts (columns: name, publisher(s))
- Pressing "Enter" on podcast goes to episode table
- Pressing "D" unsaves selected podcast


Functions related to podcasts that are not yet implemented:

- ~~Showing heart next to followed podcasts in search results~~
- ~~Ability do follow/unfollow from search results~~
- Ability to follow/unfollow from episode table


Possible additions:
- Add name of podcast to episode table

I'm willing to work on these other functionalities too but I thought it would be good to get feedback for what I have already done. 
And I was wondering if it was okay to add a `selected_show_id` field to `App`, because to implement following/unfollowing from the episode table we need the viewed show's id. Another way would be calling `get_an_episode` from rspotify to get the `FullEpisode` instead of `SimplifiedEpisode` of which the former includes a reference to the show but this might create unnecessary overhead.

EDIT:
Hearts and follow/unfollow now works in podcasts search results.
