### PR TITLE
Make the liked icon configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,11 @@ behavior:
   tick_rate_milliseconds: 250
   # Enable text emphasis (typically italic/bold text styling). Disabling this might be important if the terminal config is otherwise restricted and rendering text escapes interferes with the UI.
   enable_text_emphasis: true
-  # controls whether to show a loading indicator in the top right of the UI whenever communicating with Spotify API
+  # Controls whether to show a loading indicator in the top right of the UI whenever communicating with Spotify API
   show_loading_indicator: true
+  # Determines the text icon to display next to "liked" Spotify items, such as
+  # liked songs and albums, or followed artists. Can be any length string.
+  liked_icon: "♥"
 
 keybindings:
   # Key stroke can be used if it only uses two keys:

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -395,7 +395,7 @@ where
             song_name += "▶ "
           }
           if app.liked_song_ids_set.contains(&id) {
-            song_name += "♥ ";
+            song_name += app.user_config.liked_icon();
           }
 
           song_name += &item.name;
@@ -423,7 +423,7 @@ where
         .map(|item| {
           let mut artist = String::new();
           if app.followed_artist_ids_set.contains(&item.id.to_owned()) {
-            artist.push_str("♥ ");
+            artist.push_str(app.user_config.liked_icon());
           }
           artist.push_str(&item.name.to_owned());
           artist
@@ -457,7 +457,7 @@ where
           let mut album_artist = String::new();
           if let Some(album_id) = &item.id {
             if app.saved_album_ids_set.contains(&album_id.to_owned()) {
-              album_artist.push_str("♥ ");
+              album_artist.push_str(app.user_config.liked_icon());
             }
           }
           album_artist.push_str(&format!(
@@ -925,7 +925,7 @@ where
       };
 
       let track_name = if app.liked_song_ids_set.contains(&item_id) {
-        format!("♥ {}", name)
+        format!("{} {}", app.user_config.liked_icon(), name)
       } else {
         name
       };
@@ -1191,7 +1191,7 @@ where
         let mut album_artist = String::new();
         if let Some(album_id) = &item.id {
           if app.saved_album_ids_set.contains(&album_id.to_owned()) {
-            album_artist.push_str("♥ ");
+            album_artist.push_str(app.user_config.liked_icon());
           }
         }
         album_artist.push_str(&format!(
@@ -1219,7 +1219,7 @@ where
       .map(|item| {
         let mut artist = String::new();
         if app.followed_artist_ids_set.contains(&item.id.to_owned()) {
-          artist.push_str("♥ ");
+          artist.push_str(app.user_config.liked_icon());
         }
         artist.push_str(&item.name.to_owned());
         artist
@@ -1347,7 +1347,11 @@ where
       .map(|album_page| TableItem {
         id: album_page.album.id.to_owned(),
         format: vec![
-          format!("♥ {}", &album_page.album.name),
+          format!(
+            "{} {}",
+            app.user_config.liked_icon(),
+            &album_page.album.name
+          ),
           create_artist_string(&album_page.album.artists),
           album_page.album.release_date.to_owned(),
         ],
@@ -1731,10 +1735,10 @@ fn draw_table<B>(
           }
         }
 
-        // Show this ♥ if the song is liked
+        // Show this the liked icon if the song is liked
         if let Some(liked_idx) = header.get_index(ColumnId::Liked) {
           if app.liked_song_ids_set.contains(item.id.as_str()) {
-            formatted_row[liked_idx] = " ♥".to_string();
+            formatted_row[liked_idx] = app.user_config.liked_icon().to_string();
           }
         }
       }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -395,7 +395,7 @@ where
             song_name += "▶ "
           }
           if app.liked_song_ids_set.contains(&id) {
-            song_name += app.user_config.liked_icon();
+            song_name += &app.user_config.padded_liked_icon();
           }
 
           song_name += &item.name;
@@ -423,7 +423,7 @@ where
         .map(|item| {
           let mut artist = String::new();
           if app.followed_artist_ids_set.contains(&item.id.to_owned()) {
-            artist.push_str(app.user_config.liked_icon());
+            artist.push_str(&app.user_config.padded_liked_icon());
           }
           artist.push_str(&item.name.to_owned());
           artist
@@ -457,7 +457,7 @@ where
           let mut album_artist = String::new();
           if let Some(album_id) = &item.id {
             if app.saved_album_ids_set.contains(&album_id.to_owned()) {
-              album_artist.push_str(app.user_config.liked_icon());
+              album_artist.push_str(&app.user_config.padded_liked_icon());
             }
           }
           album_artist.push_str(&format!(
@@ -925,7 +925,7 @@ where
       };
 
       let track_name = if app.liked_song_ids_set.contains(&item_id) {
-        format!("{} {}", app.user_config.liked_icon(), name)
+        format!("{} {}", &app.user_config.padded_liked_icon(), name)
       } else {
         name
       };
@@ -1191,7 +1191,7 @@ where
         let mut album_artist = String::new();
         if let Some(album_id) = &item.id {
           if app.saved_album_ids_set.contains(&album_id.to_owned()) {
-            album_artist.push_str(app.user_config.liked_icon());
+            album_artist.push_str(&app.user_config.padded_liked_icon());
           }
         }
         album_artist.push_str(&format!(
@@ -1219,7 +1219,7 @@ where
       .map(|item| {
         let mut artist = String::new();
         if app.followed_artist_ids_set.contains(&item.id.to_owned()) {
-          artist.push_str(app.user_config.liked_icon());
+          artist.push_str(&app.user_config.padded_liked_icon());
         }
         artist.push_str(&item.name.to_owned());
         artist
@@ -1349,7 +1349,7 @@ where
         format: vec![
           format!(
             "{} {}",
-            app.user_config.liked_icon(),
+            app.user_config.padded_liked_icon(),
             &album_page.album.name
           ),
           create_artist_string(&album_page.album.artists),
@@ -1738,7 +1738,7 @@ fn draw_table<B>(
         // Show this the liked icon if the song is liked
         if let Some(liked_idx) = header.get_index(ColumnId::Liked) {
           if app.liked_song_ids_set.contains(item.id.as_str()) {
-            formatted_row[liked_idx] = app.user_config.liked_icon().to_string();
+            formatted_row[liked_idx] = app.user_config.padded_liked_icon();
           }
         }
       }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -925,7 +925,7 @@ where
       };
 
       let track_name = if app.liked_song_ids_set.contains(&item_id) {
-        format!("{} {}", &app.user_config.padded_liked_icon(), name)
+        format!("{}{}", &app.user_config.padded_liked_icon(), name)
       } else {
         name
       };
@@ -1348,7 +1348,7 @@ where
         id: album_page.album.id.to_owned(),
         format: vec![
           format!(
-            "{} {}",
+            "{}{}",
             app.user_config.padded_liked_icon(),
             &album_page.album.name
           ),

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -449,8 +449,8 @@ impl UserConfig {
     }
   }
 
-  pub fn liked_icon(&self) -> &str {
-    &self.behavior.liked_icon
+  pub fn padded_liked_icon(&self) -> String {
+    format!("{} ", &self.behavior.liked_icon)
   }
 }
 

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -212,6 +212,7 @@ pub struct BehaviorConfigString {
   pub tick_rate_milliseconds: Option<u64>,
   pub enable_text_emphasis: Option<bool>,
   pub show_loading_indicator: Option<bool>,
+  pub liked_icon: Option<String>,
 }
 
 #[derive(Clone)]
@@ -221,6 +222,7 @@ pub struct BehaviorConfig {
   pub tick_rate_milliseconds: u64,
   pub enable_text_emphasis: bool,
   pub show_loading_indicator: bool,
+  pub liked_icon: String,
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -276,6 +278,7 @@ impl UserConfig {
         tick_rate_milliseconds: 250,
         enable_text_emphasis: true,
         show_loading_indicator: true,
+        liked_icon: "♥".to_string(),
       },
       path_to_config: None,
     }
@@ -405,6 +408,10 @@ impl UserConfig {
       self.behavior.show_loading_indicator = loading_indicator;
     }
 
+    if let Some(liked_icon) = behavior_config.liked_icon {
+      self.behavior.liked_icon = liked_icon;
+    }
+
     Ok(())
   }
 
@@ -440,6 +447,10 @@ impl UserConfig {
     } else {
       Ok(())
     }
+  }
+
+  pub fn liked_icon(&self) -> &str {
+    &self.behavior.liked_icon
   }
 }
 


### PR DESCRIPTION
This closes #625.

Sorry this took longer than it should have. I got distracted.

Anyways, it's a pretty simple change. I only have one reservation about the naming.

Here's a screenshot of it in action:
![image](https://user-images.githubusercontent.com/10730394/99153290-83d90880-2675-11eb-9da7-1a98cb235dfc.png)

And here's the accompanying config:
```yaml
theme:
  ...

behavior:
  liked_icon: "★"
```