### PR TITLE
Updated Spotify API connection instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,14 +169,17 @@ Instructions on how to set this up will be shown when you first run the app.
 But here they are again:
 
 1. Go to the [Spotify dashboard](https://developer.spotify.com/dashboard/applications)
-1. Click `Create a Client ID` and create an app
+1. Click `Create an app`
+    - You now can see your `Client ID` and `Client Secret`
 1. Now click `Edit Settings`
 1. Add `http://localhost:8888/callback` to the Redirect URIs
+1. Scroll down and click `Save`
 1. You are now ready to authenticate with Spotify!
 1. Go back to the terminal
 1. Run `spt`
 1. Enter your `Client ID`
 1. Enter your `Client Secret`
+1. Press enter to confirm the default port (8888)
 1. You will be redirected to an official Spotify webpage to ask you for permissions.
 1. After accepting the permissions, you'll be redirected to localhost. If all goes well, the redirect URL will be parsed automatically and now you're done. If the local webserver fails for some reason you'll be redirected to a blank webpage that might say something like "Connection Refused" since no server is running. Regardless, copy the URL and paste into the prompt in the terminal.
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ But here they are again:
 1. Run `spt`
 1. Enter your `Client ID`
 1. Enter your `Client Secret`
-1. Press enter to confirm the default port (8888)
+1. Press enter to confirm the default port (8888) or enter a custom port
 1. You will be redirected to an official Spotify webpage to ask you for permissions.
 1. After accepting the permissions, you'll be redirected to localhost. If all goes well, the redirect URL will be parsed automatically and now you're done. If the local webserver fails for some reason you'll be redirected to a blank webpage that might say something like "Connection Refused" since no server is running. Regardless, copy the URL and paste into the prompt in the terminal.
 


### PR DESCRIPTION
I noticed that the `Create a Client ID` button doesn't exist anymore in the [Spotify dashboard](https://developer.spotify.com/dashboard/applications), so I updated the instructions accordingly.