### PR TITLE
Handle invalid Client ID/Secret

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -181,7 +181,7 @@ impl ClientConfig {
     }
   }
 
-  fn validate_client_key(key: &String) -> Result<()> {
+  fn validate_client_key(key: &str) -> Result<()> {
     const EXPECTED_LEN: usize = 32;
     if key.len() != EXPECTED_LEN {
       Err(Error::from(std::io::Error::new(

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,33 +127,8 @@ impl ClientConfig {
         number += 1;
       }
 
-      let mut client_id = String::new();
-      loop {
-        println!("\nEnter your Client ID: ");
-        stdin().read_line(&mut client_id)?;
-        client_id = client_id.trim().to_string();
-        match ClientConfig::is_client_key_valid(&client_id) {
-          Ok(_) => break,
-          Err(error_string) => {
-            println!("Invalid Client ID: {}", error_string);
-            client_id.clear();
-          }
-        };
-      }
-
-      let mut client_secret = String::new();
-      loop {
-        println!("\nEnter your Client Secret: ");
-        stdin().read_line(&mut client_secret)?;
-        client_secret = client_secret.trim().to_string();
-        match ClientConfig::is_client_key_valid(&client_secret) {
-          Ok(_) => break,
-          Err(error_string) => {
-            println!("Invalid Client Secret: {}", error_string);
-            client_secret.clear();
-          }
-        };
-      }
+      let client_id = ClientConfig::get_client_key_from_input("Client ID");
+      let client_secret = ClientConfig::get_client_key_from_input("Client Secret");
 
       let mut port = String::new();
       println!("\nEnter port of redirect uri (default {}): ", DEFAULT_PORT);
@@ -178,6 +153,22 @@ impl ClientConfig {
       self.port = config_yml.port;
 
       Ok(())
+    }
+  }
+
+  fn get_client_key_from_input(type_label: &'static str) -> String {
+    let mut client_key = String::new();
+    loop {
+      println!("\nEnter your {}: ", type_label);
+      stdin().read_line(&mut client_key)?;
+      client_key = client_key.trim().to_string();
+      match ClientConfig::is_client_key_valid(&client_key) {
+        Ok(_) => return client_key,
+        Err(error_string) => {
+          println!("Invalid {}: {}", type_label, error_string);
+          client_key.clear();
+        }
+      };
     }
   }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,8 +127,8 @@ impl ClientConfig {
         number += 1;
       }
 
-      let client_id = ClientConfig::get_client_key_from_input("Client ID");
-      let client_secret = ClientConfig::get_client_key_from_input("Client Secret");
+      let client_id = ClientConfig::get_client_key_from_input("Client ID")?;
+      let client_secret = ClientConfig::get_client_key_from_input("Client Secret")?;
 
       let mut port = String::new();
       println!("\nEnter port of redirect uri (default {}): ", DEFAULT_PORT);
@@ -156,14 +156,14 @@ impl ClientConfig {
     }
   }
 
-  fn get_client_key_from_input(type_label: &'static str) -> String {
+  fn get_client_key_from_input(type_label: &'static str) -> Result<String> {
     let mut client_key = String::new();
     loop {
       println!("\nEnter your {}: ", type_label);
       stdin().read_line(&mut client_key)?;
       client_key = client_key.trim().to_string();
       match ClientConfig::is_client_key_valid(&client_key) {
-        Ok(_) => return client_key,
+        Ok(_) => return Ok(client_key),
         Err(error_string) => {
           println!("Invalid {}: {}", type_label, error_string);
           client_key.clear();
@@ -172,7 +172,7 @@ impl ClientConfig {
     }
   }
 
-  fn is_client_key_valid(key: &String) -> Result<bool, String> {
+  fn is_client_key_valid(key: &String) -> Result<(), String> {
     const EXPECTED_LEN: usize = 32;
     if key.len() != EXPECTED_LEN {
       Err(format!(
@@ -183,7 +183,7 @@ impl ClientConfig {
     } else if !key.chars().all(|c| c.is_digit(16)) {
       Err("invalid character found (must be hex digits)".to_string())
     } else {
-      Ok(true)
+      Ok(())
     }
   }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,14 +127,33 @@ impl ClientConfig {
         number += 1;
       }
 
-      // TODO: Handle empty input?
       let mut client_id = String::new();
-      println!("\nEnter your Client ID: ");
-      stdin().read_line(&mut client_id)?;
+      loop {
+        println!("\nEnter your Client ID: ");
+        stdin().read_line(&mut client_id)?;
+        client_id = client_id.trim().to_string();
+        match ClientConfig::is_client_key_valid(&client_id) {
+          Ok(_) => break,
+          Err(error_string) => {
+            println!("Invalid Client ID: {}", error_string);
+            client_id.clear();
+          }
+        };
+      }
 
       let mut client_secret = String::new();
-      println!("\nEnter your Client Secret: ");
-      stdin().read_line(&mut client_secret)?;
+      loop {
+        println!("\nEnter your Client Secret: ");
+        stdin().read_line(&mut client_secret)?;
+        client_secret = client_secret.trim().to_string();
+        match ClientConfig::is_client_key_valid(&client_secret) {
+          Ok(_) => break,
+          Err(error_string) => {
+            println!("Invalid Client Secret: {}", error_string);
+            client_secret.clear();
+          }
+        };
+      }
 
       let mut port = String::new();
       println!("\nEnter port of redirect uri (default {}): ", DEFAULT_PORT);
@@ -142,8 +161,8 @@ impl ClientConfig {
       let port = port.trim().parse::<u16>().unwrap_or(DEFAULT_PORT);
 
       let config_yml = ClientConfig {
-        client_id: client_id.trim().to_string(),
-        client_secret: client_secret.trim().to_string(),
+        client_id,
+        client_secret,
         device_id: None,
         port: Some(port),
       };
@@ -159,6 +178,21 @@ impl ClientConfig {
       self.port = config_yml.port;
 
       Ok(())
+    }
+  }
+
+  fn is_client_key_valid(key: &String) -> Result<bool, String> {
+    const EXPECTED_LEN: usize = 32;
+    if key.len() != EXPECTED_LEN {
+      Err(format!(
+        "invalid length: {} (must be {})",
+        key.len(),
+        EXPECTED_LEN,
+      ))
+    } else if !key.chars().all(|c| c.is_digit(16)) {
+      Err("invalid character found (must be hex digits)".to_string())
+    } else {
+      Ok(true)
     }
   }
 }


### PR DESCRIPTION
### Changes
* Asks user for Client ID/Secret until a valid input is entered (32 hex digits)

This makes it such that the config file is not written unless valid inputs are entered, so the user will not have to manually edit or delete the config file.