### PR TITLE
Fix url to share the current album/show

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -692,7 +692,7 @@ impl App {
         PlayingItem::Track(track) => {
           if let Err(e) = clipboard.set_contents(format!(
             "https://open.spotify.com/album/{}",
-            track.id.to_owned().unwrap_or_default()
+            track.album.id.to_owned().unwrap_or_default()
           )) {
             self.handle_error(anyhow!("failed to set clipboard content: {}", e));
           }


### PR DESCRIPTION
A small fix that changes the url to the currently playing album from `https://open.spotify.com/album/{track.id}`
to `https://open.spotify.com/album/{track.album.id}`. The old url didn't open for me, the new does.
