### PR TITLE
Add ability to seek from the CLI

### DIFF
--- a/src/cli/clap.rs
+++ b/src/cli/clap.rs
@@ -126,7 +126,11 @@ two songs back, you can use `spt pb -ppp` and so on.",
         .takes_value(true)
         .value_name("±SECONDS")
         .allow_hyphen_values(true)
-        .help("Jumps SECONDS forwards (+) or backwards (-)"),
+        .help("Jumps SECONDS forwards (+) or backwards (-)")
+        .long_help(
+          "For example: `spt pb --seek +10` jumps ten second forwards, `spt pb --seek -10` ten \
+seconds backwards and `spt pb --seek 10` to the tenth second of the track.",
+        ),
     )
     .arg(
       Arg::with_name("volume")

--- a/src/cli/clap.rs
+++ b/src/cli/clap.rs
@@ -48,6 +48,7 @@ can be used together
       format_arg()
         .default_value("%f %s %t - %a")
         .default_value_ifs(&[
+          ("seek", None, "%f %s %t - %a %r"),
           ("volume", None, "%v% %f %s %t - %a"),
           ("transfer", None, "%f %s %t - %a on %d"),
         ]),

--- a/src/cli/clap.rs
+++ b/src/cli/clap.rs
@@ -120,6 +120,14 @@ two songs back, you can use `spt pb -ppp` and so on.",
         ),
     )
     .arg(
+      Arg::with_name("seek")
+        .long("seek")
+        .takes_value(true)
+        .value_name("±SECONDS")
+        .allow_hyphen_values(true)
+        .help("Jumps SECONDS forwards (+) or backwards (-)"),
+    )
+    .arg(
       Arg::with_name("volume")
         .short("v")
         .long("volume")

--- a/src/cli/cli_app.rs
+++ b/src/cli/cli_app.rs
@@ -316,7 +316,7 @@ impl<'a> CliApp<'a> {
       seconds * 1000
     };
 
-    // Check if position_to_seek is greater than 
+    // Check if position_to_seek is greater than
     // duration (next track) or negative (previous track)
     if position_to_seek > duration {
       self.jump(&JumpDirection::Next).await;

--- a/src/cli/cli_app.rs
+++ b/src/cli/cli_app.rs
@@ -306,6 +306,9 @@ impl<'a> CliApp<'a> {
     let position_to_seek = if seconds_str.starts_with('+') {
       current_pos + ms
     } else if seconds_str.starts_with('-') {
+      // Jump to the beginning if the position_to_seek would be
+      // negative, must be checked before the calculation to avoid
+      // an 'underflow'
       if ms > current_pos {
         0u32
       } else {
@@ -316,8 +319,7 @@ impl<'a> CliApp<'a> {
       seconds * 1000
     };
 
-    // Check if position_to_seek is greater than
-    // duration (next track) or negative (previous track)
+    // Check if position_to_seek is greater than duration (next track)
     if position_to_seek > duration {
       self.jump(&JumpDirection::Next).await;
     } else {

--- a/src/cli/cli_app.rs
+++ b/src/cli/cli_app.rs
@@ -303,9 +303,9 @@ impl<'a> CliApp<'a> {
     // Convert secs to ms
     let ms = seconds * 1000;
     // Calculate new positon
-    let position_to_seek = if seconds_str.starts_with("+") {
+    let position_to_seek = if seconds_str.starts_with('+') {
       current_pos + ms
-    } else if seconds_str.starts_with("-") {
+    } else if seconds_str.starts_with('-') {
       if ms > current_pos {
         0u32
       } else {

--- a/src/cli/cli_app.rs
+++ b/src/cli/cli_app.rs
@@ -278,7 +278,10 @@ impl<'a> CliApp<'a> {
     };
 
     let current_pos = {
-      self.net.handle_network_event(IoEvent::GetCurrentPlayback).await;
+      self
+        .net
+        .handle_network_event(IoEvent::GetCurrentPlayback)
+        .await;
       let app = self.net.app.lock().await;
       if let Some(CurrentlyPlaybackContext {
         progress_ms: Some(ms),
@@ -287,7 +290,7 @@ impl<'a> CliApp<'a> {
       {
         (ms / 1000) as u32
       } else {
-        return Err(anyhow!("no context available"))
+        return Err(anyhow!("no context available"));
       }
     };
 
@@ -302,7 +305,10 @@ impl<'a> CliApp<'a> {
     };
 
     // This seeks to a position in the current song
-    self.net.handle_network_event(IoEvent::Seek(position_to_seek)).await;
+    self
+      .net
+      .handle_network_event(IoEvent::Seek(position_to_seek))
+      .await;
     Ok(())
   }
 

--- a/src/cli/cli_app.rs
+++ b/src/cli/cli_app.rs
@@ -374,7 +374,10 @@ impl<'a> CliApp<'a> {
     let mut hs = match playing_item {
       PlayingItem::Track(track) => {
         let id = track.id.clone().unwrap_or_default();
-        let mut hs = Format::from_type(FormatType::Track(Box::new(track)));
+        let mut hs = Format::from_type(FormatType::Track(Box::new(track.clone())));
+        if let Some(ms) = context.progress_ms {
+          hs.push(Format::Position((ms, track.duration_ms)))
+        }
         hs.push(Format::Flags((
           context.repeat_state,
           context.shuffle_state,
@@ -383,7 +386,10 @@ impl<'a> CliApp<'a> {
         hs
       }
       PlayingItem::Episode(episode) => {
-        let mut hs = Format::from_type(FormatType::Episode(Box::new(episode)));
+        let mut hs = Format::from_type(FormatType::Episode(Box::new(episode.clone())));
+        if let Some(ms) = context.progress_ms {
+          hs.push(Format::Position((ms, episode.duration_ms)))
+        }
         hs.push(Format::Flags((
           context.repeat_state,
           context.shuffle_state,

--- a/src/cli/handle.rs
+++ b/src/cli/handle.rs
@@ -82,6 +82,9 @@ pub async fn handle_matches(
       if let Some(vol) = matches.value_of("volume") {
         cli.volume(vol.to_string()).await?;
       }
+      if let Some(secs) = matches.value_of("seek") {
+        cli.seek(secs.to_string()).await?;
+      }
 
       // Print out the status if no errors were found
       cli.get_status(format.to_string()).await

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -144,6 +144,8 @@ pub enum Format {
   Uri(String),
   Device(String),
   Volume(u32),
+  // Current position, duration
+  Position((u32, u32)),
   // This is a bit long, should it be splitted up?
   Flags((RepeatState, bool, bool)),
   Playing(bool),
@@ -206,6 +208,9 @@ impl Format {
       // Because this match statements
       // needs to return a &String, I have to do it this way
       Self::Volume(s) => s.to_string(),
+      Self::Position((curr, duration)) => {
+        crate::ui::util::display_track_progress(*curr as u128, *duration)
+      }
       Self::Flags((r, s, l)) => {
         let like = if *l {
           conf.behavior.liked_icon
@@ -252,6 +257,7 @@ impl Format {
       Self::Uri(_) => "%u",
       Self::Device(_) => "%d",
       Self::Volume(_) => "%v",
+      Self::Position(_) => "%r",
       Self::Flags(_) => "%f",
       Self::Playing(_) => "%s",
     }


### PR DESCRIPTION
- Add new `--seek` to jump forward, backwards
- Add new `%r` to the format options to display the current progress
- Add a longer help to the `--seek` option

For example: `spt pb --seek +10` jumps ten second forwards, `spt pb --seek -10` ten seconds backwards and
`spt pb --seek 10` to the tenth second of the track.