### PR TITLE
Fix Default tick rate

### DIFF
--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -285,7 +285,7 @@ impl UserConfig {
       behavior: BehaviorConfig {
         seek_milliseconds: 5 * 1000,
         volume_increment: 10,
-        tick_rate_milliseconds: 250,
+        tick_rate_milliseconds: 16,
         enable_text_emphasis: true,
         show_loading_indicator: true,
         liked_icon: " ".to_string(),


### PR DESCRIPTION
In my opinion, fixing the tick rate to be 16ms - roughly 60fps, makes it appear much smoother, without compromising on performance.