### PR TITLE
README: change update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,7 @@ cargo install spotify-tui
 
 This method will build the binary from source.
 
-To update, run
-
-```bash
-cargo install spotify-tui --force
-```
+To update, run the same command again.
 
 #### Note on Linux
 


### PR DESCRIPTION
Recent versions of Cargo check for updates when using `install` and no longer require `--force`. See [this page of the Cargo Book](https://doc.rust-lang.org/cargo/commands/cargo-install.html):

> If the package is already installed, Cargo will reinstall it if the installed version does not appear to be up-to-date. If any of the following values change, then Cargo will reinstall the package: [...]