### PR TITLE
`enforce_wide_search_bar` to make search bar bigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,9 @@ behavior:
   enable_text_emphasis: true
   # Controls whether to show a loading indicator in the top right of the UI whenever communicating with Spotify API
   show_loading_indicator: true
+  # Disables the responsive layout that makes the search bar smaller on bigger
+  # screens and enforces a wide search bar
+  enforce_wide_search_bar: false
   # Determines the text icon to display next to "liked" Spotify items, such as
   # liked songs and albums, or followed artists. Can be any length string.
   # These icons require a patched nerd font.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -122,7 +122,7 @@ where
   // Check for the width and change the contraints accordingly
   let chunks = Layout::default()
     .direction(Direction::Horizontal)
-    .constraints(if app.size.width >= SMALL_TERMINAL_WIDTH {
+    .constraints(if app.size.width >= SMALL_TERMINAL_WIDTH && !app.user_config.behavior.show_big_search {
       [Constraint::Percentage(65), Constraint::Percentage(35)].as_ref()
     } else {
       [Constraint::Percentage(90), Constraint::Percentage(10)].as_ref()
@@ -174,7 +174,7 @@ where
 {
   let margin = util::get_main_layout_margin(app);
   // Responsive layout: new one kicks in at width 150 or higher
-  if app.size.width >= SMALL_TERMINAL_WIDTH {
+  if app.size.width >= SMALL_TERMINAL_WIDTH && !app.user_config.behavior.show_big_search {
     let parent_layout = Layout::default()
       .direction(Direction::Vertical)
       .constraints([Constraint::Min(1), Constraint::Length(6)].as_ref())
@@ -323,7 +323,7 @@ where
   B: Backend,
 {
   // Check for width to make a responsive layout
-  if app.size.width >= SMALL_TERMINAL_WIDTH {
+  if app.size.width >= SMALL_TERMINAL_WIDTH && !app.user_config.behavior.show_big_search {
     let chunks = Layout::default()
       .direction(Direction::Vertical)
       .constraints(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -122,11 +122,14 @@ where
   // Check for the width and change the contraints accordingly
   let chunks = Layout::default()
     .direction(Direction::Horizontal)
-    .constraints(if app.size.width >= SMALL_TERMINAL_WIDTH && !app.user_config.behavior.enforce_wide_search_bar {
-      [Constraint::Percentage(65), Constraint::Percentage(35)].as_ref()
-    } else {
-      [Constraint::Percentage(90), Constraint::Percentage(10)].as_ref()
-    })
+    .constraints(
+      if app.size.width >= SMALL_TERMINAL_WIDTH && !app.user_config.behavior.enforce_wide_search_bar
+      {
+        [Constraint::Percentage(65), Constraint::Percentage(35)].as_ref()
+      } else {
+        [Constraint::Percentage(90), Constraint::Percentage(10)].as_ref()
+      },
+    )
     .split(layout_chunk);
 
   let current_route = app.get_current_route();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -122,7 +122,7 @@ where
   // Check for the width and change the contraints accordingly
   let chunks = Layout::default()
     .direction(Direction::Horizontal)
-    .constraints(if app.size.width >= SMALL_TERMINAL_WIDTH && !app.user_config.behavior.show_big_search {
+    .constraints(if app.size.width >= SMALL_TERMINAL_WIDTH && !app.user_config.behavior.enforce_wide_search_bar {
       [Constraint::Percentage(65), Constraint::Percentage(35)].as_ref()
     } else {
       [Constraint::Percentage(90), Constraint::Percentage(10)].as_ref()
@@ -174,7 +174,7 @@ where
 {
   let margin = util::get_main_layout_margin(app);
   // Responsive layout: new one kicks in at width 150 or higher
-  if app.size.width >= SMALL_TERMINAL_WIDTH && !app.user_config.behavior.show_big_search {
+  if app.size.width >= SMALL_TERMINAL_WIDTH && !app.user_config.behavior.enforce_wide_search_bar {
     let parent_layout = Layout::default()
       .direction(Direction::Vertical)
       .constraints([Constraint::Min(1), Constraint::Length(6)].as_ref())
@@ -323,7 +323,7 @@ where
   B: Backend,
 {
   // Check for width to make a responsive layout
-  if app.size.width >= SMALL_TERMINAL_WIDTH && !app.user_config.behavior.show_big_search {
+  if app.size.width >= SMALL_TERMINAL_WIDTH && !app.user_config.behavior.enforce_wide_search_bar {
     let chunks = Layout::default()
       .direction(Direction::Vertical)
       .constraints(

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -212,7 +212,7 @@ pub struct BehaviorConfigString {
   pub tick_rate_milliseconds: Option<u64>,
   pub enable_text_emphasis: Option<bool>,
   pub show_loading_indicator: Option<bool>,
-  pub show_big_search: Option<bool>,
+  pub enforce_wide_search_bar: Option<bool>,
   pub liked_icon: Option<String>,
   pub shuffle_icon: Option<String>,
   pub repeat_track_icon: Option<String>,
@@ -228,7 +228,7 @@ pub struct BehaviorConfig {
   pub tick_rate_milliseconds: u64,
   pub enable_text_emphasis: bool,
   pub show_loading_indicator: bool,
-  pub show_big_search: bool,
+  pub enforce_wide_search_bar: bool,
   pub liked_icon: String,
   pub shuffle_icon: String,
   pub repeat_track_icon: String,
@@ -290,7 +290,7 @@ impl UserConfig {
         tick_rate_milliseconds: 250,
         enable_text_emphasis: true,
         show_loading_indicator: true,
-        show_big_search: false,
+        enforce_wide_search_bar: false,
         liked_icon: "♥".to_string(),
         shuffle_icon: "🔀".to_string(),
         repeat_track_icon: "🔂".to_string(),
@@ -426,8 +426,8 @@ impl UserConfig {
       self.behavior.show_loading_indicator = loading_indicator;
     }
 
-    if let Some(big_search) = behavior_config.show_big_search {
-      self.behavior.show_big_search = big_search;
+    if let Some(wide_search_bar) = behavior_config.enforce_wide_search_bar {
+      self.behavior.enforce_wide_search_bar = wide_search_bar;
     }
 
     if let Some(liked_icon) = behavior_config.liked_icon {

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -212,6 +212,7 @@ pub struct BehaviorConfigString {
   pub tick_rate_milliseconds: Option<u64>,
   pub enable_text_emphasis: Option<bool>,
   pub show_loading_indicator: Option<bool>,
+  pub show_big_search: Option<bool>,
   pub liked_icon: Option<String>,
   pub shuffle_icon: Option<String>,
   pub repeat_track_icon: Option<String>,
@@ -227,6 +228,7 @@ pub struct BehaviorConfig {
   pub tick_rate_milliseconds: u64,
   pub enable_text_emphasis: bool,
   pub show_loading_indicator: bool,
+  pub show_big_search: bool,
   pub liked_icon: String,
   pub shuffle_icon: String,
   pub repeat_track_icon: String,
@@ -288,6 +290,7 @@ impl UserConfig {
         tick_rate_milliseconds: 250,
         enable_text_emphasis: true,
         show_loading_indicator: true,
+        show_big_search: false,
         liked_icon: "♥".to_string(),
         shuffle_icon: "🔀".to_string(),
         repeat_track_icon: "🔂".to_string(),
@@ -421,6 +424,10 @@ impl UserConfig {
 
     if let Some(loading_indicator) = behavior_config.show_loading_indicator {
       self.behavior.show_loading_indicator = loading_indicator;
+    }
+
+    if let Some(big_search) = behavior_config.show_big_search {
+      self.behavior.show_big_search = big_search;
     }
 
     if let Some(liked_icon) = behavior_config.liked_icon {


### PR DESCRIPTION
This adds an option with the name `behavior.enforce_wide_search_bar` to make the search bar wider. Fix for #737 