### PR TITLE
Replace black and white default colors with reset.

### DIFF
--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -53,7 +53,7 @@ impl Default for Theme {
   fn default() -> Self {
     Theme {
       analysis_bar: Color::LightCyan,
-      analysis_bar_text: Color::Black,
+      analysis_bar_text: Color::Reset,
       active: Color::Cyan,
       banner: Color::LightCyan,
       error_border: Color::Red,
@@ -64,10 +64,10 @@ impl Default for Theme {
       playbar_background: Color::Black,
       playbar_progress: Color::LightCyan,
       playbar_progress_text: Color::LightCyan,
-      playbar_text: Color::White,
+      playbar_text: Color::Reset,
       selected: Color::LightCyan,
-      text: Color::White,
-      header: Color::White,
+      text: Color::Reset,
+      header: Color::Reset,
     }
   }
 }


### PR DESCRIPTION
Previously, text would be white, which is not visible on bright color
schemes. The color for non-highlighted text now uses the default
foreground color of the users terminal emulator, making it visible in
any theme. The only visual change in dark color schemes is that the
playbar text might go from black to white, depending on the users
terminal emulator (some terminal emulators swap fore- and background
colors on a colored background depending on the background color; this
is IMO the correct behavior anyway).