### PR TITLE
Implement movement counts for up/down navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .env
 .spotify_token_cache.json 
 .cached_device_id.txt
+.idea/
 spotify-tui.sketch
 
 spt*.txt

--- a/src/app.rs
+++ b/src/app.rs
@@ -323,6 +323,7 @@ pub struct App {
   pub spotify_token_expiry: SystemTime,
   pub dialog: Option<String>,
   pub confirm: bool,
+  pub movement_count: Option<String>,
 }
 
 impl Default for App {
@@ -410,6 +411,7 @@ impl Default for App {
       spotify_token_expiry: SystemTime::now(),
       dialog: None,
       confirm: false,
+      movement_count: None,
     }
   }
 }

--- a/src/handlers/album_list.rs
+++ b/src/handlers/album_list.rs
@@ -9,15 +9,21 @@ pub fn handler(key: Key, app: &mut App) {
     k if common_key_events::left_event(k) => common_key_events::handle_left_event(app),
     k if common_key_events::down_event(k) => {
       if let Some(albums) = &mut app.library.saved_albums.get_results(None) {
-        let next_index =
-          common_key_events::on_down_press_handler(&albums.items, Some(app.album_list_index));
+        let next_index = common_key_events::on_down_press_handler(
+          &albums.items,
+          Some(app.album_list_index),
+          &mut app.movement_count,
+        );
         app.album_list_index = next_index;
       }
     }
     k if common_key_events::up_event(k) => {
       if let Some(albums) = &mut app.library.saved_albums.get_results(None) {
-        let next_index =
-          common_key_events::on_up_press_handler(&albums.items, Some(app.album_list_index));
+        let next_index = common_key_events::on_up_press_handler(
+          &albums.items,
+          Some(app.album_list_index),
+          &mut app.movement_count,
+        );
         app.album_list_index = next_index;
       }
     }
@@ -39,6 +45,7 @@ pub fn handler(key: Key, app: &mut App) {
         app.album_list_index = next_index;
       }
     }
+    k if common_key_events::count_event(k) => common_key_events::handle_count_event(k, app),
     Key::Enter => {
       if let Some(albums) = app.library.saved_albums.get_results(None) {
         if let Some(selected_album) = albums.items.get(app.album_list_index) {

--- a/src/handlers/album_tracks.rs
+++ b/src/handlers/album_tracks.rs
@@ -14,6 +14,7 @@ pub fn handler(key: Key, app: &mut App) {
           let next_index = common_key_events::on_down_press_handler(
             &selected_album.album.tracks.items,
             Some(app.saved_album_tracks_index),
+            &mut app.movement_count,
           );
           app.saved_album_tracks_index = next_index;
         };
@@ -23,6 +24,7 @@ pub fn handler(key: Key, app: &mut App) {
           let next_index = common_key_events::on_down_press_handler(
             &selected_album_simplified.tracks.items,
             Some(selected_album_simplified.selected_index),
+            &mut app.movement_count,
           );
           selected_album_simplified.selected_index = next_index;
         }
@@ -34,6 +36,7 @@ pub fn handler(key: Key, app: &mut App) {
           let next_index = common_key_events::on_up_press_handler(
             &selected_album.album.tracks.items,
             Some(app.saved_album_tracks_index),
+            &mut app.movement_count,
           );
           app.saved_album_tracks_index = next_index;
         };
@@ -43,6 +46,7 @@ pub fn handler(key: Key, app: &mut App) {
           let next_index = common_key_events::on_up_press_handler(
             &selected_album_simplified.tracks.items,
             Some(selected_album_simplified.selected_index),
+            &mut app.movement_count,
           );
           selected_album_simplified.selected_index = next_index;
         }
@@ -51,6 +55,7 @@ pub fn handler(key: Key, app: &mut App) {
     k if common_key_events::high_event(k) => handle_high_event(app),
     k if common_key_events::middle_event(k) => handle_middle_event(app),
     k if common_key_events::low_event(k) => handle_low_event(app),
+    k if common_key_events::count_event(k) => common_key_events::handle_count_event(k, app),
     Key::Char('s') => handle_save_event(app),
     Key::Char('w') => handle_save_album_event(app),
     Key::Enter => match app.album_table_context {

--- a/src/handlers/artist.rs
+++ b/src/handlers/artist.rs
@@ -10,6 +10,7 @@ fn handle_down_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_down_press_handler(
           &artist.top_tracks,
           Some(artist.selected_top_track_index),
+          &mut app.movement_count,
         );
         artist.selected_top_track_index = next_index;
       }
@@ -17,6 +18,7 @@ fn handle_down_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_down_press_handler(
           &artist.albums.items,
           Some(artist.selected_album_index),
+          &mut app.movement_count,
         );
         artist.selected_album_index = next_index;
       }
@@ -24,6 +26,7 @@ fn handle_down_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_down_press_handler(
           &artist.related_artists,
           Some(artist.selected_related_artist_index),
+          &mut app.movement_count,
         );
         artist.selected_related_artist_index = next_index;
       }
@@ -56,6 +59,7 @@ fn handle_up_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_up_press_handler(
           &artist.top_tracks,
           Some(artist.selected_top_track_index),
+          &mut app.movement_count,
         );
         artist.selected_top_track_index = next_index;
       }
@@ -63,6 +67,7 @@ fn handle_up_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_up_press_handler(
           &artist.albums.items,
           Some(artist.selected_album_index),
+          &mut app.movement_count,
         );
         artist.selected_album_index = next_index;
       }
@@ -70,6 +75,7 @@ fn handle_up_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_up_press_handler(
           &artist.related_artists,
           Some(artist.selected_related_artist_index),
+          &mut app.movement_count,
         );
         artist.selected_related_artist_index = next_index;
       }
@@ -284,6 +290,7 @@ pub fn handler(key: Key, app: &mut App) {
           handle_low_press_on_selected_block(app);
         }
       }
+      k if common_key_events::count_event(k) => common_key_events::handle_count_event(k, app),
       Key::Enter => {
         if artist.artist_selected_block != ArtistBlock::Empty {
           handle_enter_event_on_selected_block(app);

--- a/src/handlers/artist_albums.rs
+++ b/src/handlers/artist_albums.rs
@@ -12,6 +12,7 @@ pub fn handler(key: Key, app: &mut App) {
                 let next_index = common_key_events::on_down_press_handler(
                     &artist_albums.albums.items,
                     Some(artist_albums.selected_index),
+                    &mut app.movement_count,
                 );
                 artist_albums.selected_index = next_index;
             }
@@ -25,6 +26,7 @@ pub fn handler(key: Key, app: &mut App) {
                 artist_albums.selected_index = next_index;
             }
         }
+        k if common_key_events::count_event(k) => common_key_events::handle_count_event(k, app),
         Key::Enter => {
             if let Some(artist_albums) = &mut app.artist_albums {
                 if let Some(selected_album) = artist_albums

--- a/src/handlers/artists.rs
+++ b/src/handlers/artists.rs
@@ -10,15 +10,21 @@ pub fn handler(key: Key, app: &mut App) {
     k if common_key_events::left_event(k) => common_key_events::handle_left_event(app),
     k if common_key_events::down_event(k) => {
       if let Some(artists) = &mut app.library.saved_artists.get_results(None) {
-        let next_index =
-          common_key_events::on_down_press_handler(&artists.items, Some(app.artists_list_index));
+        let next_index = common_key_events::on_down_press_handler(
+          &artists.items,
+          Some(app.artists_list_index),
+          &mut app.movement_count,
+        );
         app.artists_list_index = next_index;
       }
     }
     k if common_key_events::up_event(k) => {
       if let Some(artists) = &mut app.library.saved_artists.get_results(None) {
-        let next_index =
-          common_key_events::on_up_press_handler(&artists.items, Some(app.artists_list_index));
+        let next_index = common_key_events::on_up_press_handler(
+          &artists.items,
+          Some(app.artists_list_index),
+          &mut app.movement_count,
+        );
         app.artists_list_index = next_index;
       }
     }
@@ -40,6 +46,7 @@ pub fn handler(key: Key, app: &mut App) {
         app.artists_list_index = next_index;
       }
     }
+    k if common_key_events::count_event(k) => common_key_events::handle_count_event(k, app),
     Key::Enter => {
       let artists = app.artists.to_owned();
       if !artists.is_empty() {

--- a/src/handlers/episode_table.rs
+++ b/src/handlers/episode_table.rs
@@ -11,15 +11,21 @@ pub fn handler(key: Key, app: &mut App) {
     k if common_key_events::left_event(k) => common_key_events::handle_left_event(app),
     k if common_key_events::down_event(k) => {
       if let Some(episodes) = &mut app.library.show_episodes.get_results(None) {
-        let next_index =
-          common_key_events::on_down_press_handler(&episodes.items, Some(app.episode_list_index));
+        let next_index = common_key_events::on_down_press_handler(
+          &episodes.items,
+          Some(app.episode_list_index),
+          &mut app.movement_count,
+        );
         app.episode_list_index = next_index;
       }
     }
     k if common_key_events::up_event(k) => {
       if let Some(episodes) = &mut app.library.show_episodes.get_results(None) {
-        let next_index =
-          common_key_events::on_up_press_handler(&episodes.items, Some(app.episode_list_index));
+        let next_index = common_key_events::on_up_press_handler(
+          &episodes.items,
+          Some(app.episode_list_index),
+          &mut app.movement_count,
+        );
         app.episode_list_index = next_index;
       }
     }
@@ -41,6 +47,7 @@ pub fn handler(key: Key, app: &mut App) {
         app.episode_list_index = next_index;
       }
     }
+    k if common_key_events::count_event(k) => common_key_events::handle_count_event(k, app),
     Key::Enter => {
       on_enter(app);
     }

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -12,12 +12,16 @@ pub fn handler(key: Key, app: &mut App) {
       let next_index = common_key_events::on_down_press_handler(
         &LIBRARY_OPTIONS,
         Some(app.library.selected_index),
+        &mut app.movement_count,
       );
       app.library.selected_index = next_index;
     }
     k if common_key_events::up_event(k) => {
-      let next_index =
-        common_key_events::on_up_press_handler(&LIBRARY_OPTIONS, Some(app.library.selected_index));
+      let next_index = common_key_events::on_up_press_handler(
+        &LIBRARY_OPTIONS,
+        Some(app.library.selected_index),
+        &mut app.movement_count,
+      );
       app.library.selected_index = next_index;
     }
     k if common_key_events::high_event(k) => {
@@ -32,6 +36,7 @@ pub fn handler(key: Key, app: &mut App) {
       let next_index = common_key_events::on_low_press_handler(&LIBRARY_OPTIONS);
       app.library.selected_index = next_index
     }
+    k if common_key_events::count_event(k) => common_key_events::handle_count_event(k, app),
     // `library` should probably be an array of structs with enums rather than just using indexes
     // like this
     Key::Enter => match app.library.selected_index {

--- a/src/handlers/made_for_you.rs
+++ b/src/handlers/made_for_you.rs
@@ -10,15 +10,21 @@ pub fn handler(key: Key, app: &mut App) {
     k if common_key_events::left_event(k) => common_key_events::handle_left_event(app),
     k if common_key_events::up_event(k) => {
       if let Some(playlists) = &mut app.library.made_for_you_playlists.get_results(None) {
-        let next_index =
-          common_key_events::on_up_press_handler(&playlists.items, Some(app.made_for_you_index));
+        let next_index = common_key_events::on_up_press_handler(
+          &playlists.items,
+          Some(app.made_for_you_index),
+          &mut app.movement_count,
+        );
         app.made_for_you_index = next_index;
       }
     }
     k if common_key_events::down_event(k) => {
       if let Some(playlists) = &mut app.library.made_for_you_playlists.get_results(None) {
-        let next_index =
-          common_key_events::on_down_press_handler(&playlists.items, Some(app.made_for_you_index));
+        let next_index = common_key_events::on_down_press_handler(
+          &playlists.items,
+          Some(app.made_for_you_index),
+          &mut app.movement_count,
+        );
         app.made_for_you_index = next_index;
       }
     }
@@ -40,6 +46,7 @@ pub fn handler(key: Key, app: &mut App) {
         app.made_for_you_index = next_index;
       }
     }
+    k if common_key_events::count_event(k) => common_key_events::handle_count_event(k, app),
     Key::Enter => {
       if let (Some(playlists), selected_playlist_index) = (
         &app.library.made_for_you_playlists.get_results(Some(0)),

--- a/src/handlers/playlist.rs
+++ b/src/handlers/playlist.rs
@@ -13,8 +13,11 @@ pub fn handler(key: Key, app: &mut App) {
       match &app.playlists {
         Some(p) => {
           if let Some(selected_playlist_index) = app.selected_playlist_index {
-            let next_index =
-              common_key_events::on_down_press_handler(&p.items, Some(selected_playlist_index));
+            let next_index = common_key_events::on_down_press_handler(
+              &p.items,
+              Some(selected_playlist_index),
+              &mut app.movement_count,
+            );
             app.selected_playlist_index = Some(next_index);
           }
         }
@@ -24,8 +27,11 @@ pub fn handler(key: Key, app: &mut App) {
     k if common_key_events::up_event(k) => {
       match &app.playlists {
         Some(p) => {
-          let next_index =
-            common_key_events::on_up_press_handler(&p.items, app.selected_playlist_index);
+          let next_index = common_key_events::on_up_press_handler(
+            &p.items,
+            app.selected_playlist_index,
+            &mut app.movement_count,
+          );
           app.selected_playlist_index = Some(next_index);
         }
         None => {}
@@ -58,6 +64,7 @@ pub fn handler(key: Key, app: &mut App) {
         None => {}
       };
     }
+    k if common_key_events::count_event(k) => common_key_events::handle_count_event(k, app),
     Key::Enter => {
       if let (Some(playlists), Some(selected_playlist_index)) =
         (&app.playlists, &app.selected_playlist_index)

--- a/src/handlers/podcasts.rs
+++ b/src/handlers/podcasts.rs
@@ -10,15 +10,21 @@ pub fn handler(key: Key, app: &mut App) {
     k if common_key_events::left_event(k) => common_key_events::handle_left_event(app),
     k if common_key_events::down_event(k) => {
       if let Some(shows) = &mut app.library.saved_shows.get_results(None) {
-        let next_index =
-          common_key_events::on_down_press_handler(&shows.items, Some(app.shows_list_index));
+        let next_index = common_key_events::on_down_press_handler(
+          &shows.items,
+          Some(app.shows_list_index),
+          &mut app.movement_count,
+        );
         app.shows_list_index = next_index;
       }
     }
     k if common_key_events::up_event(k) => {
       if let Some(shows) = &mut app.library.saved_shows.get_results(None) {
-        let next_index =
-          common_key_events::on_up_press_handler(&shows.items, Some(app.shows_list_index));
+        let next_index = common_key_events::on_up_press_handler(
+          &shows.items,
+          Some(app.shows_list_index),
+          &mut app.movement_count,
+        );
         app.shows_list_index = next_index;
       }
     }
@@ -40,6 +46,7 @@ pub fn handler(key: Key, app: &mut App) {
         app.shows_list_index = next_index;
       }
     }
+    k if common_key_events::count_event(k) => common_key_events::handle_count_event(k, app),
     Key::Enter => {
       if let Some(shows) = app.library.saved_shows.get_results(None) {
         if let Some(selected_show) = shows.items.get(app.shows_list_index).cloned() {

--- a/src/handlers/recently_played.rs
+++ b/src/handlers/recently_played.rs
@@ -9,6 +9,7 @@ pub fn handler(key: Key, app: &mut App) {
         let next_index = common_key_events::on_down_press_handler(
           &recently_played_result.items,
           Some(app.recently_played.index),
+          &mut app.movement_count,
         );
         app.recently_played.index = next_index;
       }
@@ -18,6 +19,7 @@ pub fn handler(key: Key, app: &mut App) {
         let next_index = common_key_events::on_up_press_handler(
           &recently_played_result.items,
           Some(app.recently_played.index),
+          &mut app.movement_count,
         );
         app.recently_played.index = next_index;
       }
@@ -49,6 +51,7 @@ pub fn handler(key: Key, app: &mut App) {
         };
       };
     }
+    k if common_key_events::count_event(k) => common_key_events::handle_count_event(k, app),
     Key::Enter => {
       if let Some(recently_played_result) = &app.recently_played.result.clone() {
         let track_uris: Vec<String> = recently_played_result

--- a/src/handlers/search_results.rs
+++ b/src/handlers/search_results.rs
@@ -16,6 +16,7 @@ fn handle_down_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_down_press_handler(
           &result.items,
           app.search_results.selected_album_index,
+          &mut app.movement_count,
         );
         app.search_results.selected_album_index = Some(next_index);
       }
@@ -25,6 +26,7 @@ fn handle_down_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_down_press_handler(
           &result.items,
           app.search_results.selected_tracks_index,
+          &mut app.movement_count,
         );
         app.search_results.selected_tracks_index = Some(next_index);
       }
@@ -34,6 +36,7 @@ fn handle_down_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_down_press_handler(
           &result.items,
           app.search_results.selected_artists_index,
+          &mut app.movement_count,
         );
         app.search_results.selected_artists_index = Some(next_index);
       }
@@ -43,6 +46,7 @@ fn handle_down_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_down_press_handler(
           &result.items,
           app.search_results.selected_playlists_index,
+          &mut app.movement_count,
         );
         app.search_results.selected_playlists_index = Some(next_index);
       }
@@ -52,6 +56,7 @@ fn handle_down_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_down_press_handler(
           &result.items,
           app.search_results.selected_shows_index,
+          &mut app.movement_count,
         );
         app.search_results.selected_shows_index = Some(next_index);
       }
@@ -89,6 +94,7 @@ fn handle_up_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_up_press_handler(
           &result.items,
           app.search_results.selected_album_index,
+          &mut app.movement_count,
         );
         app.search_results.selected_album_index = Some(next_index);
       }
@@ -98,6 +104,7 @@ fn handle_up_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_up_press_handler(
           &result.items,
           app.search_results.selected_tracks_index,
+          &mut app.movement_count,
         );
         app.search_results.selected_tracks_index = Some(next_index);
       }
@@ -107,6 +114,7 @@ fn handle_up_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_up_press_handler(
           &result.items,
           app.search_results.selected_artists_index,
+          &mut app.movement_count,
         );
         app.search_results.selected_artists_index = Some(next_index);
       }
@@ -116,6 +124,7 @@ fn handle_up_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_up_press_handler(
           &result.items,
           app.search_results.selected_playlists_index,
+          &mut app.movement_count,
         );
         app.search_results.selected_playlists_index = Some(next_index);
       }
@@ -125,6 +134,7 @@ fn handle_up_press_on_selected_block(app: &mut App) {
         let next_index = common_key_events::on_up_press_handler(
           &result.items,
           app.search_results.selected_shows_index,
+          &mut app.movement_count,
         );
         app.search_results.selected_shows_index = Some(next_index);
       }
@@ -492,6 +502,7 @@ pub fn handler(key: Key, app: &mut App) {
         handle_low_press_on_selected_block(app)
       }
     }
+    k if common_key_events::count_event(k) => common_key_events::handle_count_event(k, app),
     // Handle pressing enter when block is selected to start playing track
     Key::Enter => match app.search_results.selected_block {
       SearchResultBlock::Empty => handle_enter_event_on_hovered_block(app),

--- a/src/handlers/select_device.rs
+++ b/src/handlers/select_device.rs
@@ -14,8 +14,11 @@ pub fn handler(key: Key, app: &mut App) {
       match &app.devices {
         Some(p) => {
           if let Some(selected_device_index) = app.selected_device_index {
-            let next_index =
-              common_key_events::on_down_press_handler(&p.devices, Some(selected_device_index));
+            let next_index = common_key_events::on_down_press_handler(
+              &p.devices,
+              Some(selected_device_index),
+              &mut app.movement_count,
+            );
             app.selected_device_index = Some(next_index);
           }
         }
@@ -26,8 +29,11 @@ pub fn handler(key: Key, app: &mut App) {
       match &app.devices {
         Some(p) => {
           if let Some(selected_device_index) = app.selected_device_index {
-            let next_index =
-              common_key_events::on_up_press_handler(&p.devices, Some(selected_device_index));
+            let next_index = common_key_events::on_up_press_handler(
+              &p.devices,
+              Some(selected_device_index),
+              &mut app.movement_count,
+            );
             app.selected_device_index = Some(next_index);
           }
         }

--- a/src/handlers/track_table.rs
+++ b/src/handlers/track_table.rs
@@ -14,6 +14,7 @@ pub fn handler(key: Key, app: &mut App) {
       let next_index = common_key_events::on_down_press_handler(
         &app.track_table.tracks,
         Some(app.track_table.selected_index),
+        &mut app.movement_count,
       );
       app.track_table.selected_index = next_index;
     }
@@ -21,6 +22,7 @@ pub fn handler(key: Key, app: &mut App) {
       let next_index = common_key_events::on_up_press_handler(
         &app.track_table.tracks,
         Some(app.track_table.selected_index),
+        &mut app.movement_count,
       );
       app.track_table.selected_index = next_index;
     }
@@ -36,6 +38,7 @@ pub fn handler(key: Key, app: &mut App) {
       let next_index = common_key_events::on_low_press_handler(&app.track_table.tracks);
       app.track_table.selected_index = next_index;
     }
+    k if common_key_events::count_event(k) => common_key_events::handle_count_event(k, app),
     Key::Enter => {
       on_enter(app);
     }

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -337,7 +337,7 @@ impl UserConfig {
           check_reserved_keys(self.keys.$name)?;
         }
       };
-    };
+    }
 
     to_keys!(back);
     to_keys!(next_page);
@@ -376,7 +376,7 @@ impl UserConfig {
           self.theme.$name = parse_theme_item(&theme_item)?;
         }
       };
-    };
+    }
 
     to_theme_item!(active);
     to_theme_item!(banner);


### PR DESCRIPTION
**Overview**
Implements movement counts for up/down navigation. E.g. pressing "5j" moves the selection index down by five, and "5k" moves it up by five. I plan to add absolute and relative line numbering eventually to make this feature more useful.

**Testing**
Added some tests. `cargo test` passes.

I manually checked the following:
- Happy-path up/down movements with counts
- Wrapping behavior is preserved when movement count is one, selection is the first element, and movement is up
- Wrapping behavior is preserved when movement count is one, selection is the last element, and movement is down
- When movement count is larger than one and results in an out-of-bounds index, the index is set to 0 if moving up and length - 1 if moving down.

I'm pretty sure I got every list. Please double-check and let me know if I missed anything.
