### PR TITLE
feat: dump errors to log, rather than consume ui

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -599,8 +599,19 @@ impl App {
   }
 
   pub fn handle_error(&mut self, e: anyhow::Error) {
-    self.push_navigation_stack(RouteId::Error, ActiveBlock::Error);
-    self.api_error = e.to_string();
+    match &self.user_config.behavior.error_log {
+      Some(file) => {
+        std::fs::write(file, e.to_string()).expect(&format!(
+          "Failed to write {} to {}",
+          e.to_string(),
+          file
+        ));
+      }
+      None => {
+        self.push_navigation_stack(RouteId::Error, ActiveBlock::Error);
+        self.api_error = e.to_string();
+      }
+    }
   }
 
   pub fn toggle_playback(&mut self) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -600,13 +600,11 @@ impl App {
 
   pub fn handle_error(&mut self, e: anyhow::Error) {
     match &self.user_config.behavior.error_log {
-      Some(file) => {
-        std::fs::write(file, e.to_string()).expect(&format!(
-          "Failed to write {} to {}",
-          e.to_string(),
-          file
-        ));
-      }
+      Some(file) => std::fs::write(file, e.to_string()).expect(&format!(
+        "Failed to write {} to {}",
+        e.to_string(),
+        file
+      )),
       None => {
         self.push_navigation_stack(RouteId::Error, ActiveBlock::Error);
         self.api_error = e.to_string();

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -457,6 +457,10 @@ impl UserConfig {
       self.behavior.repeat_context_icon = repeat_context_icon;
     }
 
+    if let Some(error_log) = behavior_config.error_log {
+      self.behavior.error_log = Some(error_log);
+    }
+
     Ok(())
   }
 

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -219,6 +219,7 @@ pub struct BehaviorConfigString {
   pub repeat_context_icon: Option<String>,
   pub playing_icon: Option<String>,
   pub paused_icon: Option<String>,
+  pub error_log: Option<String>,
 }
 
 #[derive(Clone)]
@@ -235,6 +236,7 @@ pub struct BehaviorConfig {
   pub repeat_context_icon: String,
   pub playing_icon: String,
   pub paused_icon: String,
+  pub error_log: Option<String>,
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -297,6 +299,7 @@ impl UserConfig {
         repeat_context_icon: "🔁".to_string(),
         playing_icon: "▶".to_string(),
         paused_icon: "⏸".to_string(),
+        error_log: None,
       },
       path_to_config: None,
     }


### PR DESCRIPTION
This is meant to help with #762.  I'll add tests and make it less of a hack if proven functional.