### PR TITLE
feat: Allow wayland builds without xcb dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,16 @@ dirs = "3.0.1"
 clap = "2.33.3"
 unicode-width = "0.1.8"
 backtrace = "0.3.56"
-arboard = "1.1.0"
+arboard = { version =  "1.1.0", optional = true }
 crossterm = "0.19"
 tokio = { version = "0.2", features = ["full"] }
 rand = "0.8.3"
 anyhow = "1.0.38"
+
+[features]
+default = ["x11"]
+x11 = ["arboard"]
+wayland = []
 
 [[bin]]
 bench = false

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,7 @@
 use super::user_config::UserConfig;
 use crate::network::IoEvent;
+// this create in only used in coping the album/song url to the clipboard
+#[cfg(feature = "x11")]
 use anyhow::anyhow;
 use rspotify::{
   model::{
@@ -27,6 +29,7 @@ use std::{
 };
 use tui::layout::Rect;
 
+#[cfg(feature = "x11")]
 use arboard::Clipboard;
 
 pub const LIBRARY_OPTIONS: [&str; 6] = [
@@ -310,6 +313,7 @@ pub struct App {
   pub album_list_index: usize,
   pub made_for_you_index: usize,
   pub artists_list_index: usize,
+  #[cfg(feature = "x11")]
   pub clipboard: Option<Clipboard>,
   pub shows_list_index: usize,
   pub episode_list_index: usize,
@@ -399,6 +403,7 @@ impl Default for App {
       selected_show_full: None,
       user: None,
       instant_since_last_current_playback_poll: Instant::now(),
+      #[cfg(feature = "x11")]
       clipboard: Clipboard::new().ok(),
       help_docs_size: 0,
       help_menu_page: 0,
@@ -664,6 +669,10 @@ impl App {
     }
   }
 
+  #[cfg(feature = "wayland")]
+  pub fn copy_song_url(&mut self) {}
+
+  #[cfg(feature = "x11")]
   pub fn copy_song_url(&mut self) {
     let clipboard = match &mut self.clipboard {
       Some(ctx) => ctx,
@@ -695,6 +704,10 @@ impl App {
     }
   }
 
+  #[cfg(feature = "wayland")]
+  pub fn copy_album_url(&mut self) {}
+
+  #[cfg(feature = "x11")]
   pub fn copy_album_url(&mut self) {
     let clipboard = match &mut self.clipboard {
       Some(ctx) => ctx,

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -72,11 +72,13 @@ pub fn get_help_docs(key_bindings: &KeyBindings) -> Vec<Vec<String>> {
       key_bindings.shuffle.to_string(),
       String::from("General"),
     ],
+    #[cfg(feature = "x11")]
     vec![
       String::from("Copy url to currently playing song/episode"),
       key_bindings.copy_song_url.to_string(),
       String::from("General"),
     ],
+    #[cfg(feature = "x11")]
     vec![
       String::from("Copy url to currently playing album/show"),
       key_bindings.copy_album_url.to_string(),


### PR DESCRIPTION
The arbout carte is used to interact with the system clipboard. This
however imposes a dependency on xcb on the crate for Linux/Unix builds.

On a pure Wayland system this is undesirable as interaction with the
system clipboard via xcb in only possible if the user runs a xwayland
server. This cause spotify-cli to require a dependency to a x11 c lib
without providing any functionally to the user.

This change intoduces to new cargo features to spotify-cli: `x11` and
`wayland`.

The `x11` feature is in the default feature and will preserve the
current application behavior.

The `wayland` feature will disable the dependency onto arboard and use
`#[cfg(feature = "wayland")]` attributes to disable code using this
crate, as well as any reference from the help menu to any copy
functionally.

I currently plan to investigate how to bring this behavior back to the wayland platform.

Looking forward to your code review. :)