### PR TITLE
Pressing `d` twice requires `q` twice to exit

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -626,19 +626,18 @@ impl App {
   // The navigation_stack actually only controls the large block to the right of `library` and
   // `playlists`
   pub fn push_navigation_stack(&mut self, next_route_id: RouteId, next_active_block: ActiveBlock) {
-    if self
+    if !self
       .navigation_stack
       .last()
       .map(|last_route_id| last_route_id.id == next_route_id)
       .unwrap_or(false)
     {
-      return;
+      self.navigation_stack.push(Route {
+        id: next_route_id,
+        active_block: next_active_block,
+        hovered_block: next_active_block,
+      });
     }
-    self.navigation_stack.push(Route {
-      id: next_route_id,
-      active_block: next_active_block,
-      hovered_block: next_active_block,
-    });
   }
 
   pub fn pop_navigation_stack(&mut self) -> Option<Route> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,6 +28,7 @@ use std::{
 use tui::layout::Rect;
 
 use arboard::Clipboard;
+use crate::app::RouteId::SelectedDevice;
 
 pub const LIBRARY_OPTIONS: [&str; 6] = [
   "Made For You",
@@ -634,6 +635,8 @@ impl App {
   }
 
   pub fn pop_navigation_stack(&mut self) -> Option<Route> {
+    self.navigation_stack.dedup_by_key(|x| x.id == SelectedDevice);
+
     if self.navigation_stack.len() == 1 {
       None
     } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -629,7 +629,7 @@ impl App {
     if !self
       .navigation_stack
       .last()
-      .map(|last_route_id| last_route_id.id == next_route_id)
+      .map(|last_route| last_route.id == next_route_id)
       .unwrap_or(false)
     {
       self.navigation_stack.push(Route {

--- a/src/app.rs
+++ b/src/app.rs
@@ -626,6 +626,14 @@ impl App {
   // The navigation_stack actually only controls the large block to the right of `library` and
   // `playlists`
   pub fn push_navigation_stack(&mut self, next_route_id: RouteId, next_active_block: ActiveBlock) {
+    if self
+      .navigation_stack
+      .last()
+      .map(|last_route_id| last_route_id.id == next_route_id)
+      .unwrap_or(false)
+    {
+      return;
+    }
     self.navigation_stack.push(Route {
       id: next_route_id,
       active_block: next_active_block,
@@ -634,8 +642,6 @@ impl App {
   }
 
   pub fn pop_navigation_stack(&mut self) -> Option<Route> {
-    self.navigation_stack.dedup_by(|a, b| a.id == b.id);
-
     if self.navigation_stack.len() == 1 {
       None
     } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,7 +28,6 @@ use std::{
 use tui::layout::Rect;
 
 use arboard::Clipboard;
-use crate::app::RouteId::SelectedDevice;
 
 pub const LIBRARY_OPTIONS: [&str; 6] = [
   "Made For You",
@@ -635,7 +634,7 @@ impl App {
   }
 
   pub fn pop_navigation_stack(&mut self) -> Option<Route> {
-    self.navigation_stack.dedup_by_key(|x| x.id == SelectedDevice);
+    self.navigation_stack.dedup_by(|a, b| a.id == b.id);
 
     if self.navigation_stack.len() == 1 {
       None


### PR DESCRIPTION
Hi guys 👋,

First attempt at a PR here and attempted to resolve [issue](https://github.com/Rigellute/spotify-tui/issues/821)

Did this by `dedup`ing any routes on the navigation stack with matching ids.

---

The device selector popup can be opened multiple times by pressing `d` more than once.
To get back to the main menu, each of these needs to be closed separately by pressing `q` the same number of times.

It would be nicer if pressing `q` only once always goes back to the main menu.

E.g, actual behavior:

press `d`
press `d`
press `q`
You're seeing the device selector
expected behavior:

press `d`
press `d`
press `q`
You're seeing the main menu