### PR TITLE
Add option to set window title to "spt - Spotify TUI" on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ behavior:
   repeat_context_icon: 🔁
   playing_icon: ▶
   paused_icon: ⏸
+  # Sets the window title to "spt - Spotify TUI" via ANSI escape code.
+  set_window_title: true
 
 keybindings:
   # Key stroke can be used if it only uses two keys:

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,9 @@ use crossterm::{
   event::{DisableMouseCapture, EnableMouseCapture},
   execute,
   style::Print,
-  terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+  terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen, SetTitle,
+  },
   ExecutableCommand,
 };
 use network::{get_spotify, IoEvent, Network};
@@ -268,7 +270,12 @@ async fn start_ui(user_config: UserConfig, app: &Arc<Mutex<App>>) -> Result<()> 
   execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
   enable_raw_mode()?;
 
-  let backend = CrosstermBackend::new(stdout);
+  let mut backend = CrosstermBackend::new(stdout);
+
+  if user_config.behavior.set_window_title {
+    backend.execute(SetTitle("spt - Spotify TUI"))?;
+  }
+
   let mut terminal = Terminal::new(backend)?;
   terminal.hide_cursor()?;
 

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -219,6 +219,7 @@ pub struct BehaviorConfigString {
   pub repeat_context_icon: Option<String>,
   pub playing_icon: Option<String>,
   pub paused_icon: Option<String>,
+  pub set_window_title: Option<bool>,
 }
 
 #[derive(Clone)]
@@ -235,6 +236,7 @@ pub struct BehaviorConfig {
   pub repeat_context_icon: String,
   pub playing_icon: String,
   pub paused_icon: String,
+  pub set_window_title: bool,
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -297,6 +299,7 @@ impl UserConfig {
         repeat_context_icon: "🔁".to_string(),
         playing_icon: "▶".to_string(),
         paused_icon: "⏸".to_string(),
+        set_window_title: true,
       },
       path_to_config: None,
     }
@@ -452,6 +455,10 @@ impl UserConfig {
 
     if let Some(repeat_context_icon) = behavior_config.repeat_context_icon {
       self.behavior.repeat_context_icon = repeat_context_icon;
+    }
+
+    if let Some(set_window_title) = behavior_config.set_window_title {
+      self.behavior.set_window_title = set_window_title;
     }
 
     Ok(())


### PR DESCRIPTION
This adds an option to set the window title to "Spotify TUI" on startup. 

This is very handy when switching windows via something like dmenu, since it makes the terminal window where spotify-tui is running easy to find. 

There are a few choices that I wasn't sure about though:

- I've added the configuration option under "behavior", is there a better place for it? 
- I've set it to enabled by default, since it's a very well supported xterm feature so it shouldn't cause problems for most people. Should it default to false to maintain existing behavior on upgrade?
- Since the binary is called spt, i've set the title to "spt - Spotify TUI", in case people want to locate the window by the name of the command they used to start the application. But just "Spotify TUI" is probably nicer and maybe locating the window by spt is not enough to justify messing with it?

Thanks!