### PR TITLE
Feature: show queued songs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ secrets.tar
 
 *.swp
 tags
+
+/.vscode

--- a/src/app.rs
+++ b/src/app.rs
@@ -137,6 +137,7 @@ pub enum ActiveBlock {
   MadeForYou,
   Artists,
   BasicView,
+  Queue,
   Dialog(DialogContext),
 }
 
@@ -317,12 +318,15 @@ pub struct App {
   pub help_menu_page: u32,
   pub help_menu_max_lines: u32,
   pub help_menu_offset: u32,
+  pub queue_menu_offset: u32,
+  pub queue_menu_page: u32,
   pub is_loading: bool,
   io_tx: Option<Sender<IoEvent>>,
   pub is_fetching_current_playback: bool,
   pub spotify_token_expiry: SystemTime,
   pub dialog: Option<String>,
   pub confirm: bool,
+  pub song_queue: Vec<FullTrack>,
 }
 
 impl Default for App {
@@ -404,12 +408,15 @@ impl Default for App {
       help_menu_page: 0,
       help_menu_max_lines: 0,
       help_menu_offset: 0,
+      queue_menu_offset: 0,
+      queue_menu_page: 8,
       is_loading: false,
       io_tx: None,
       is_fetching_current_playback: false,
       spotify_token_expiry: SystemTime::now(),
       dialog: None,
       confirm: false,
+      song_queue: Vec::new(),
     }
   }
 }
@@ -1187,6 +1194,17 @@ impl App {
     if self.help_menu_offset > self.help_docs_size {
       self.help_menu_offset = old_offset;
       self.help_menu_page -= 1;
+    }
+  }
+
+  pub fn calculate_queue_menu_offset(&mut self) {
+    let old_offset = self.queue_menu_offset;
+    if self.help_menu_max_lines < self.song_queue.len() as u32 {
+      self.queue_menu_offset = self.queue_menu_page * self.help_menu_max_lines;
+    }
+    if self.queue_menu_offset > self.help_docs_size {
+      self.queue_menu_offset = old_offset;
+      self.queue_menu_page -= 1;
     }
   }
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -10,6 +10,7 @@ mod empty;
 mod episode_table;
 mod error_screen;
 mod help_menu;
+mod queue_menu;
 mod home;
 mod input;
 mod library;
@@ -71,6 +72,10 @@ pub fn handle_app(key: Key, app: &mut App) {
     }
     _ if key == app.user_config.keys.help => {
       app.set_current_route_state(Some(ActiveBlock::HelpMenu), None);
+    }
+
+    _ if key == Key::Char('`') => {
+      app.set_current_route_state(Some(ActiveBlock::Queue), None);
     }
 
     _ if key == app.user_config.keys.shuffle => {
@@ -164,6 +169,9 @@ fn handle_block_events(key: Key, app: &mut App) {
     }
     ActiveBlock::BasicView => {
       basic_view::handler(key, app);
+    }
+    ActiveBlock::Queue => {
+      queue_menu::handler(key, app);
     }
     ActiveBlock::Dialog(_) => {
       dialog::handler(key, app);

--- a/src/handlers/queue_menu.rs
+++ b/src/handlers/queue_menu.rs
@@ -1,0 +1,37 @@
+use super::common_key_events;
+use crate::{app::App, event::Key};
+
+#[derive(PartialEq)]
+enum Direction {
+  Up,
+  Down,
+}
+
+pub fn handler(key: Key, app: &mut App) {
+  match key {
+    k if common_key_events::down_event(k) => {
+      move_page(Direction::Down, app);
+    }
+    k if common_key_events::up_event(k) => {
+      move_page(Direction::Up, app);
+    }
+    Key::Ctrl('d') => {
+      move_page(Direction::Down, app);
+    }
+    Key::Ctrl('u') => {
+      move_page(Direction::Up, app);
+    }
+    _ => {}
+  };
+}
+
+fn move_page(direction: Direction, app: &mut App) {
+  if direction == Direction::Up {
+    if app.queue_menu_page > 0 {
+      app.queue_menu_page -= 1;
+    }
+  } else if direction == Direction::Down {
+    app.queue_menu_page += 1;
+  }
+  app.calculate_queue_menu_offset();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,6 +313,9 @@ async fn start_ui(user_config: UserConfig, app: &Arc<Mutex<App>>) -> Result<()> 
 
     let current_route = app.get_current_route();
     terminal.draw(|mut f| match current_route.active_block {
+      ActiveBlock::Queue => {
+        ui::draw_queue_menu(&mut f, &app);
+      }
       ActiveBlock::HelpMenu => {
         ui::draw_help_menu(&mut f, &app);
       }

--- a/src/network.rs
+++ b/src/network.rs
@@ -355,6 +355,9 @@ impl<'a> Network<'a> {
         match item {
           PlayingItem::Track(track) => {
             if let Some(track_id) = track.id {
+              if let Some(pos) = app.song_queue.iter().position(|t| t.id.clone().unwrap_or(String::from("")) == track_id) {
+                app.song_queue.remove(pos);
+              }
               app.dispatch(IoEvent::CurrentUserSavedTracksContains(vec![track_id]));
             };
           }
@@ -777,6 +780,7 @@ impl<'a> Network<'a> {
       .await
     {
       Ok(()) => {
+        
         self.get_current_playback().await;
       }
       Err(e) => {

--- a/src/network.rs
+++ b/src/network.rs
@@ -1472,12 +1472,26 @@ impl<'a> Network<'a> {
   }
 
   async fn add_item_to_queue(&mut self, item: String) {
+    let itm = item.clone();
     match self
       .spotify
       .add_item_to_queue(item, self.client_config.device_id.clone())
       .await
     {
-      Ok(()) => (),
+      Ok(()) => {
+        match self
+          .spotify
+          .track(&itm)
+          .await {
+            Ok(res) => {
+              let mut app = self.app.lock().await;
+              app.song_queue.push(res);
+            },
+            Err(e) => {
+              self.handle_error(anyhow!(e)).await;
+            }
+          }
+      },
       Err(e) => {
         self.handle_error(anyhow!(e)).await;
       }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -158,6 +158,11 @@ pub fn get_help_docs(key_bindings: &KeyBindings) -> Vec<Vec<String>> {
       String::from("General"),
     ],
     vec![
+      String::from("Show queued tracks"),
+      String::from("`"),
+      String::from("General"),
+    ],
+    vec![
       String::from("Enter hover mode"),
       String::from("<Esc>"),
       String::from("Selected block"),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -73,6 +73,54 @@ pub struct TableItem {
   format: Vec<String>,
 }
 
+pub fn draw_queue_menu<B>(f: &mut Frame<B>, app: &App)
+where
+  B: Backend,
+{
+  let chunks = Layout::default()
+    .direction(Direction::Vertical)
+    .constraints([Constraint::Percentage(100)].as_ref())
+    .margin(2)
+    .split(f.size());
+
+  // Create a one-column table to avoid flickering due to non-determinism when
+  // resolving constraints on widths of table columns.
+  let format_row =
+    |r: Vec<String>| -> Vec<String> { vec![format!("{:50}{:50}{:40}", r[0], r[1], r[2])] };
+
+  let queue_style = Style::default().fg(app.user_config.theme.text);
+  let header = ["Song", "Artist", "Album"];
+  let header = format_row(header.iter().map(|s| s.to_string()).collect());
+
+  let queue = app.song_queue.clone();
+  let queue_rows = queue
+    .into_iter()
+    .map(|t| vec![t.name, t.artists[0].name.clone(), t.album.name])
+    .map(format_row)
+    .collect::<Vec<Vec<String>>>();
+  let queue_rows = &queue_rows[app.help_menu_offset as usize..];
+
+  let rows = queue_rows
+    .iter()
+    .map(|item| Row::new(item.clone()).style(queue_style));
+
+  let queue_menu = Table::new(rows)
+    .header(Row::new(header))
+    .block(
+      Block::default()
+        .borders(Borders::ALL)
+        .style(queue_style)
+        .title(Span::styled(
+          "Song Queue (press <Esc> to go back)",
+          queue_style,
+        ))
+        .border_style(queue_style),
+    )
+    .style(queue_style)
+    .widths(&[Constraint::Max(140)]);
+  f.render_widget(queue_menu, chunks[0]);
+}
+
 pub fn draw_help_menu<B>(f: &mut Frame<B>, app: &App)
 where
   B: Backend,

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -203,6 +203,7 @@ pub struct KeyBindings {
   pub audio_analysis: Key,
   pub basic_view: Key,
   pub add_item_to_queue: Key,
+  pub show_queue: Key,
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -283,6 +284,7 @@ impl UserConfig {
         audio_analysis: Key::Char('v'),
         basic_view: Key::Char('B'),
         add_item_to_queue: Key::Char('z'),
+        show_queue: Key::Char('`'),
       },
       behavior: BehaviorConfig {
         seek_milliseconds: 5 * 1000,


### PR DESCRIPTION
Resolves my feature request https://github.com/Rigellute/spotify-tui/issues/841. This is probably a pretty bad implementation. I just piggy backed off of the code for the help menu and made a couple of modifications.



-  I wanted to use the Table format from the `draw_song_menu`, but I was unsure how to without major refactoring of the way tables are drawn.
- It only works for tracks
- Currently removing a song from queue whenever a song with the same ID is played, but it could be from any source. Is there any API endpoint that lets you know whether a song is played from queue? 
- I have to fetch the track info a second time in the add to queue call. Maybe this could be avoided?
- I'm also super new to rust, so comments are helpful. I would love to get this working properly so I can know what I've queued in spt