### PR TITLE
Feature/show album type in search panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Show `album_type` in Search panes [#868](https://github.com/Rigellute/spotify-tui/pull/868)
+
 ## [0.25.0] - 2021-08-24
 
 ### Fixed

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -470,9 +470,10 @@ where
             }
           }
           album_artist.push_str(&format!(
-            "{} - {}",
+            "{} - {} ({})",
             item.name.to_owned(),
-            create_artist_string(&item.artists)
+            create_artist_string(&item.artists),
+            item.album_type.as_deref().unwrap()
           ));
           album_artist
         })
@@ -1237,9 +1238,10 @@ where
           }
         }
         album_artist.push_str(&format!(
-          "{} - {}",
+          "{} - {} ({})",
           item.name.to_owned(),
-          create_artist_string(&item.artists)
+          create_artist_string(&item.artists),
+          item.album_type.as_deref().unwrap()
         ));
         album_artist
       })

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -473,7 +473,7 @@ where
             "{} - {} ({})",
             item.name.to_owned(),
             create_artist_string(&item.artists),
-            item.album_type.as_deref().unwrap()
+            item.album_type.as_deref().unwrap_or("unknown")
           ));
           album_artist
         })
@@ -1241,7 +1241,7 @@ where
           "{} - {} ({})",
           item.name.to_owned(),
           create_artist_string(&item.artists),
-          item.album_type.as_deref().unwrap()
+          item.album_type.as_deref().unwrap_or("unknown")
         ));
         album_artist
       })


### PR DESCRIPTION
The Album search panes only showed: `<album> - <artist>`, so either required a User to know which item was an album/single/etc or select each item to see if the track list looks like an album/single.

This PR updates the Album search panes to the format: `<album> - <artist> (<album_type>)`, so that it is easier to find an `album` vs `single`. 

Fixes: #868 