### PR TITLE
feat(config): check for and use XDG_CONFIG_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ But here they are again:
 
 And now you are ready to use the `spotify-tui` 🎉
 
-You can edit the config at anytime at `${HOME}/.config/spotify-tui/client.yml`. (for snap `${HOME}/snap/spt/current/.config/spotify-tui/client.yml`)
+You can edit the config at anytime at `${HOME}/.config/spotify-tui/client.yml` (respects `XDG_CONFIG_HOME`). (for snap `${HOME}/snap/spt/current/.config/spotify-tui/client.yml`)
 
 ## Usage
 
@@ -208,7 +208,7 @@ spt search "An even cooler song" --tracks --format "%t from %b" --limit 30
 
 # Configuration
 
-A configuration file is located at `${HOME}/.config/spotify-tui/config.yml`, for snap `${HOME}/snap/spt/current/.config/spotify-tui/config.yml`
+A configuration file is located at `${HOME}/.config/spotify-tui/config.yml` (respects `XDG_CONFIG_HOME`), for snap `${HOME}/snap/spt/current/.config/spotify-tui/config.yml`
 (not to be confused with client.yml which handles spotify authentication)
 
 The following is a sample config.yml file:

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use super::banner::BANNER;
 use anyhow::{anyhow, Error, Result};
 use serde::{Deserialize, Serialize};
 use std::{
-  fs,
+  env, fs,
   io::{stdin, Write},
   path::{Path, PathBuf},
 };
@@ -49,7 +49,10 @@ impl ClientConfig {
     match dirs::home_dir() {
       Some(home) => {
         let path = Path::new(&home);
-        let home_config_dir = path.join(CONFIG_DIR);
+        let home_config_dir = match env::var("XDG_CONFIG_HOME") {
+          Ok(val) => Path::new(&val).to_path_buf(),
+          Err(_e) => path.join(CONFIG_DIR),
+        };
         let app_config_dir = home_config_dir.join(APP_CONFIG_DIR);
 
         if !home_config_dir.exists() {

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -2,7 +2,7 @@ use crate::event::Key;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::{
-  fs,
+  env, fs,
   path::{Path, PathBuf},
 };
 use tui::style::Color;
@@ -309,7 +309,10 @@ impl UserConfig {
     match dirs::home_dir() {
       Some(home) => {
         let path = Path::new(&home);
-        let home_config_dir = path.join(CONFIG_DIR);
+        let home_config_dir = match env::var("XDG_CONFIG_HOME") {
+          Ok(val) => Path::new(&val).to_path_buf(),
+          Err(_e) => path.join(CONFIG_DIR),
+        };
         let app_config_dir = home_config_dir.join(APP_CONFIG_DIR);
 
         if !home_config_dir.exists() {


### PR DESCRIPTION
This checks if `XDG_CONFIG_HOME` is set and follows that, but defaults to `.config` if unset.

Because I personally use a non-default home directory layout, I was never able to use spotify-tui as it didn't respect my config directory, but I finally got around to "fix" it myself.