### PR TITLE
Fix confirmation dialog handling on playlist delete.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -768,13 +768,8 @@ impl App {
       }
       None => {
         if let Some(saved_artists) = &self.library.saved_artists.clone().get_results(None) {
-          match saved_artists.items.last() {
-            Some(last_artist) => {
-              self.dispatch(IoEvent::GetFollowedArtists(Some(last_artist.id.clone())));
-            }
-            None => {
-              return;
-            }
+          if let Some(last_artist) = saved_artists.items.last() {
+            self.dispatch(IoEvent::GetFollowedArtists(Some(last_artist.id.clone())));
           }
         }
       }

--- a/src/app.rs
+++ b/src/app.rs
@@ -158,6 +158,7 @@ pub enum RouteId {
   Podcasts,
   PodcastEpisodes,
   Recommendations,
+  Dialog,
 }
 
 #[derive(Debug)]

--- a/src/handlers/common_key_events.rs
+++ b/src/handlers/common_key_events.rs
@@ -134,6 +134,7 @@ pub fn handle_right_event(app: &mut App) {
       RouteId::Error => {}
       RouteId::Analysis => {}
       RouteId::BasicView => {}
+      RouteId::Dialog => {}
     },
     _ => {}
   };

--- a/src/handlers/playlist.rs
+++ b/src/handlers/playlist.rs
@@ -2,7 +2,7 @@ use super::{
   super::app::{App, DialogContext, TrackTableContext},
   common_key_events,
 };
-use crate::app::ActiveBlock;
+use crate::app::{ActiveBlock, RouteId};
 use crate::event::Key;
 use crate::network::IoEvent;
 
@@ -78,8 +78,10 @@ pub fn handler(key: Key, app: &mut App) {
         app.dialog = Some(selected_playlist.clone());
         app.confirm = false;
 
-        let route = app.get_current_route().id.clone();
-        app.push_navigation_stack(route, ActiveBlock::Dialog(DialogContext::PlaylistWindow));
+        app.push_navigation_stack(
+          RouteId::Dialog,
+          ActiveBlock::Dialog(DialogContext::PlaylistWindow),
+        );
       }
     }
     _ => {}

--- a/src/handlers/search_results.rs
+++ b/src/handlers/search_results.rs
@@ -527,8 +527,10 @@ pub fn handler(key: Key, app: &mut App) {
           app.dialog = Some(selected_playlist.clone());
           app.confirm = false;
 
-          let route = app.get_current_route().id.clone();
-          app.push_navigation_stack(route, ActiveBlock::Dialog(DialogContext::PlaylistSearch));
+          app.push_navigation_stack(
+            RouteId::Dialog,
+            ActiveBlock::Dialog(DialogContext::PlaylistSearch),
+          );
         }
       }
       SearchResultBlock::ShowSearch => app.user_unfollow_show(ActiveBlock::SearchResultBlock),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -276,6 +276,7 @@ where
     RouteId::SelectedDevice => {} // This is handled as a "full screen" route in main.rs
     RouteId::Analysis => {} // This is handled as a "full screen" route in main.rs
     RouteId::BasicView => {} // This is handled as a "full screen" route in main.rs
+    RouteId::Dialog => {} // This is handled in the draw_dialog function in mod.rs
   };
 }
 


### PR DESCRIPTION
Resolves #884. 

### Observations
I might not know the architecture of this application very well, but I believe I've narrowed down the root cause and drafted a quick solution. As of commit [ecddb5e](https://github.com/Rigellute/spotify-tui/commit/ecddb5eb4fb441bf46075d44cf12cd2294a251c7), the `push_navigation_stack` method of the `App` class does not actually push any element to the navigation stack if the next route's id is the same as last route's id:
```rust
// app.rs
pub fn push_navigation_stack(&mut self, next_route_id: RouteId, next_active_block: ActiveBlock) {
    if !self
      .navigation_stack
      .last()
      .map(|last_route| last_route.id == next_route_id)
      .unwrap_or(false)
    { // Enter branch only if the last route's id is different from the next route's id.
      // Push to stack...
    }
  }
```
That's the case when the uppercase `D` character is entered, when a playlist is selected - the last route's id is the same as the next route's id (`RouteId::Home`):
```rust
// playlist.rs
Key::Char('D') => {
      if let (Some(playlists), Some(selected_index)) = (&app.playlists, app.selected_playlist_index)
      {
        let selected_playlist = &playlists.items[selected_index].name;
        app.dialog = Some(selected_playlist.clone());
        app.confirm = false;

        let route = app.get_current_route().id.clone(); // Pass current route's id as the next route's id
        app.push_navigation_stack(route, ActiveBlock::Dialog(DialogContext::PlaylistWindow));
      }
    }
```
As a result, no new element is pushed to the navigation stack, hence the confirmation dialog window does not appear, and the playlist cannot be deleted.

### Solution
My solution is to add a `RouteId::Dialog`, which is specific to confirmation dialog windows. When a dialog is to be opened (e.g. when deleting a playlist), a new route (different than the current one) is pushed onto the navigation stack. Then, the logic responsible for drawing and handling user input in the confirmation dialog gets executed and works just fine.
