### PR TITLE
Skip writing client config if it is not writable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -83,8 +83,9 @@ impl ClientConfig {
     config_yml.device_id = Some(device_id);
 
     let new_config = serde_yaml::to_string(&config_yml)?;
-    let mut config_file = fs::File::create(&paths.config_file_path)?;
-    write!(config_file, "{}", new_config)?;
+    if let Ok(mut config_file) = fs::File::create(&paths.config_file_path) {
+      write!(config_file, "{}", new_config)?
+    }
     Ok(())
   }
 


### PR DESCRIPTION
In some cases, the config file may be read-only. Since it is not
imperative that it be written (everything continues to work, it just
will not remember this device ID after a restart), just skip writing.

Ideally static and dynamic configuration should be totally separated,
however that is more complicated to implement and this is a quick fix.

Partial workaround for https://github.com/Rigellute/spotify-tui/issues/579.