### PR TITLE
Fix navigating to search results after searching

### DIFF
--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -112,6 +112,7 @@ fn process_input(app: &mut App, input: String) {
   // Default fallback behavior: treat the input as a raw search phrase.
   app.dispatch(IoEvent::GetSearchResults(input, app.get_user_country()));
   app.push_navigation_stack(RouteId::Search, ActiveBlock::SearchResultBlock);
+  app.set_current_route_state(Some(ActiveBlock::SearchResultBlock), Some(ActiveBlock::SearchResultBlock));
 }
 
 fn spotify_resource_id(base: &str, uri: &str, sep: &str, resource_type: &str) -> (String, bool) {


### PR DESCRIPTION
This should fix an error I was getting where only the first search after launching spotify-tui would navigate to the search results, whereas all subsequent searches would not navigate to the results. 
