### PR TITLE
Maintains shuffle through playback contexts

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -751,6 +751,11 @@ impl<'a> Network<'a> {
       Ok(()) => {
         let mut app = self.app.lock().await;
         app.song_progress_ms = 0;
+        if let Some(current_playback_context) = &app.current_playback_context {
+            if current_playback_context.shuffle_state {
+                app.dispatch(IoEvent::Shuffle(false))
+            }
+        }
         app.dispatch(IoEvent::GetCurrentPlayback);
       }
       Err(e) => {


### PR DESCRIPTION
This edit makes it so that if someone is currently playing shuffled music, then it will re-shuffle when a new playback context is generated (i.e. user presses "enter" on a song), rather than keeping the shuffle indicator "On" but having an ordered queue.