### PR TITLE
Playlist pagination

### DIFF
--- a/src/cli/cli_app.rs
+++ b/src/cli/cli_app.rs
@@ -200,9 +200,14 @@ impl<'a> CliApp<'a> {
         }
       }
       Type::Playlist => {
-        self.net.handle_network_event(IoEvent::GetPlaylists).await;
-        if let Some(playlists) = &self.net.app.lock().await.playlists {
-          playlists
+        //TODO:This will only return the playlists in the first page
+        self
+          .net
+          .handle_network_event(IoEvent::GetPlaylists(None))
+          .await;
+        let playlists = &self.net.app.lock().await.playlists;
+        match playlists.get_results(Some(0)) {
+          Some(playlists) => playlists
             .items
             .iter()
             .map(|p| {
@@ -212,9 +217,8 @@ impl<'a> CliApp<'a> {
               )
             })
             .collect::<Vec<String>>()
-            .join("\n")
-        } else {
-          "No playlists found".to_string()
+            .join("\n"),
+          None => "No playlist found".to_string(),
         }
       }
       Type::Liked => {

--- a/src/handlers/made_for_you.rs
+++ b/src/handlers/made_for_you.rs
@@ -46,7 +46,7 @@ pub fn handler(key: Key, app: &mut App) {
         &app.made_for_you_index,
       ) {
         app.track_table.context = Some(TrackTableContext::MadeForYou);
-        app.playlist_offset = 0;
+        app.playlist_track_offset = 0;
         if let Some(selected_playlist) = playlists.items.get(selected_playlist_index.to_owned()) {
           app.made_for_you_offset = 0;
           let playlist_id = selected_playlist.id.to_owned();

--- a/src/handlers/playlist.rs
+++ b/src/handlers/playlist.rs
@@ -9,30 +9,26 @@ use crate::network::IoEvent;
 pub fn handler(key: Key, app: &mut App) {
   match key {
     k if common_key_events::right_event(k) => common_key_events::handle_right_event(app),
-    k if common_key_events::down_event(k) => {
-      match &app.playlists {
-        Some(p) => {
-          if let Some(selected_playlist_index) = app.selected_playlist_index {
-            let next_index =
-              common_key_events::on_down_press_handler(&p.items, Some(selected_playlist_index));
-            app.selected_playlist_index = Some(next_index);
-          }
-        }
-        None => {}
-      };
-    }
-    k if common_key_events::up_event(k) => {
-      match &app.playlists {
-        Some(p) => {
+    k if common_key_events::down_event(k) => match &app.playlists.get_results(None) {
+      Some(p) => {
+        if let Some(selected_playlist_index) = app.selected_playlist_index {
           let next_index =
-            common_key_events::on_up_press_handler(&p.items, app.selected_playlist_index);
+            common_key_events::on_down_press_handler(&p.items, Some(selected_playlist_index));
           app.selected_playlist_index = Some(next_index);
         }
-        None => {}
-      };
-    }
+      }
+      None => {}
+    },
+    k if common_key_events::up_event(k) => match &app.playlists.get_results(None) {
+      Some(playlist_page) => {
+        let next_index =
+          common_key_events::on_up_press_handler(&playlist_page.items, app.selected_playlist_index);
+        app.selected_playlist_index = Some(next_index);
+      }
+      None => {}
+    },
     k if common_key_events::high_event(k) => {
-      match &app.playlists {
+      match &app.playlists.get_results(None) {
         Some(_p) => {
           let next_index = common_key_events::on_high_press_handler();
           app.selected_playlist_index = Some(next_index);
@@ -41,7 +37,7 @@ pub fn handler(key: Key, app: &mut App) {
       };
     }
     k if common_key_events::middle_event(k) => {
-      match &app.playlists {
+      match &app.playlists.get_results(None) {
         Some(p) => {
           let next_index = common_key_events::on_middle_press_handler(&p.items);
           app.selected_playlist_index = Some(next_index);
@@ -50,7 +46,7 @@ pub fn handler(key: Key, app: &mut App) {
       };
     }
     k if common_key_events::low_event(k) => {
-      match &app.playlists {
+      match &app.playlists.get_results(None) {
         Some(p) => {
           let next_index = common_key_events::on_low_press_handler(&p.items);
           app.selected_playlist_index = Some(next_index);
@@ -59,25 +55,51 @@ pub fn handler(key: Key, app: &mut App) {
       };
     }
     Key::Enter => {
-      if let (Some(playlists), Some(selected_playlist_index)) =
-        (&app.playlists, &app.selected_playlist_index)
-      {
+      if let (Some(playlists), Some(selected_playlist_index)) = (
+        &app.playlists.get_results(None),
+        &app.selected_playlist_index,
+      ) {
         app.active_playlist_index = Some(selected_playlist_index.to_owned());
         app.track_table.context = Some(TrackTableContext::MyPlaylists);
-        app.playlist_offset = 0;
+        app.playlist_track_offset = 0;
         if let Some(selected_playlist) = playlists.items.get(selected_playlist_index.to_owned()) {
           let playlist_id = selected_playlist.id.to_owned();
-          app.dispatch(IoEvent::GetPlaylistTracks(playlist_id, app.playlist_offset));
+          app.dispatch(IoEvent::GetPlaylistTracks(
+            playlist_id,
+            app.playlist_track_offset,
+          ));
         }
       };
     }
+
+    k if k == app.user_config.keys.previous_page => {
+      if app.playlists.index() > 0 {
+        app.playlists.previous_page();
+        app.selected_playlist_index = Some(0)
+      }
+    }
+    k if k == app.user_config.keys.next_page => {
+      match app.playlists.get_results(Some(app.playlists.index() + 1)) {
+        Some(_) => {
+          app.playlists.next_page();
+          app.selected_playlist_index = Some(0);
+        }
+        None => {
+          if let Some(saved_playlists) = &app.playlists.get_results(None) {
+            let offset = Some(saved_playlists.offset + saved_playlists.limit);
+            app.dispatch(IoEvent::GetPlaylists(offset));
+          }
+        }
+      }
+    }
     Key::Char('D') => {
-      if let (Some(playlists), Some(selected_index)) = (&app.playlists, app.selected_playlist_index)
-      {
-        let selected_playlist = &playlists.items[selected_index].name;
+      if let (Some(playlists), Some(selected_index)) = (
+        &app.playlists.get_results(None),
+        &app.selected_playlist_index,
+      ) {
+        let selected_playlist = &playlists.items[selected_index.to_owned()].name;
         app.dialog = Some(selected_playlist.clone());
         app.confirm = false;
-
         app.push_navigation_stack(
           RouteId::Dialog,
           ActiveBlock::Dialog(DialogContext::PlaylistWindow),

--- a/src/handlers/search_results.rs
+++ b/src/handlers/search_results.rs
@@ -327,7 +327,7 @@ fn handle_enter_event_on_selected_block(app: &mut App) {
           // Go to playlist tracks table
           app.track_table.context = Some(TrackTableContext::PlaylistSearch);
           let playlist_id = playlist.id.to_owned();
-          app.dispatch(IoEvent::GetPlaylistTracks(playlist_id, app.playlist_offset));
+          app.dispatch(IoEvent::GetPlaylistTracks(playlist_id, app.playlist_track_offset));
         };
       }
     }
@@ -495,7 +495,7 @@ pub fn handler(key: Key, app: &mut App) {
     Key::Enter => match app.search_results.selected_block {
       SearchResultBlock::Empty => handle_enter_event_on_hovered_block(app),
       SearchResultBlock::PlaylistSearch => {
-        app.playlist_offset = 0;
+        app.playlist_track_offset = 0;
         handle_enter_event_on_selected_block(app);
       }
       _ => handle_enter_event_on_selected_block(app),

--- a/src/handlers/track_table.rs
+++ b/src/handlers/track_table.rs
@@ -44,17 +44,21 @@ pub fn handler(key: Key, app: &mut App) {
       match &app.track_table.context {
         Some(context) => match context {
           TrackTableContext::MyPlaylists => {
-            if let (Some(playlists), Some(selected_playlist_index)) =
-              (&app.playlists, &app.selected_playlist_index)
-            {
+            if let (Some(playlist_page), Some(selected_playlist_index)) = (
+              &app.playlists.get_results(None),
+              &app.selected_playlist_index,
+            ) {
               if let Some(selected_playlist) =
-                playlists.items.get(selected_playlist_index.to_owned())
+                playlist_page.items.get(selected_playlist_index.to_owned())
               {
                 if let Some(playlist_tracks) = &app.playlist_tracks {
-                  if app.playlist_offset + app.large_search_limit < playlist_tracks.total {
-                    app.playlist_offset += app.large_search_limit;
+                  if app.playlist_track_offset + app.large_search_limit < playlist_tracks.total {
+                    app.playlist_track_offset += app.large_search_limit;
                     let playlist_id = selected_playlist.id.to_owned();
-                    app.dispatch(IoEvent::GetPlaylistTracks(playlist_id, app.playlist_offset));
+                    app.dispatch(IoEvent::GetPlaylistTracks(
+                      playlist_id,
+                      app.playlist_track_offset,
+                    ));
                   }
                 }
               }
@@ -97,17 +101,21 @@ pub fn handler(key: Key, app: &mut App) {
       match &app.track_table.context {
         Some(context) => match context {
           TrackTableContext::MyPlaylists => {
-            if let (Some(playlists), Some(selected_playlist_index)) =
-              (&app.playlists, &app.selected_playlist_index)
-            {
-              if app.playlist_offset >= app.large_search_limit {
-                app.playlist_offset -= app.large_search_limit;
+            if let (Some(playlist_page), Some(selected_playlist_index)) = (
+              &app.playlists.get_results(None),
+              &app.selected_playlist_index,
+            ) {
+              if app.playlist_track_offset >= app.large_search_limit {
+                app.playlist_track_offset -= app.large_search_limit;
               };
               if let Some(selected_playlist) =
-                playlists.items.get(selected_playlist_index.to_owned())
+                playlist_page.items.get(selected_playlist_index.to_owned())
               {
                 let playlist_id = selected_playlist.id.to_owned();
-                app.dispatch(IoEvent::GetPlaylistTracks(playlist_id, app.playlist_offset));
+                app.dispatch(IoEvent::GetPlaylistTracks(
+                  playlist_id,
+                  app.playlist_track_offset,
+                ));
               }
             };
           }
@@ -158,9 +166,13 @@ fn play_random_song(app: &mut App) {
   if let Some(context) = &app.track_table.context {
     match context {
       TrackTableContext::MyPlaylists => {
-        let (context_uri, track_json) = match (&app.selected_playlist_index, &app.playlists) {
-          (Some(selected_playlist_index), Some(playlists)) => {
-            if let Some(selected_playlist) = playlists.items.get(selected_playlist_index.to_owned())
+        let (context_uri, track_json) = match (
+          &app.selected_playlist_index,
+          &app.playlists.get_results(None),
+        ) {
+          (Some(selected_playlist_index), Some(playlist_page)) => {
+            if let Some(selected_playlist) =
+              playlist_page.items.get(selected_playlist_index.to_owned())
             {
               (
                 Some(selected_playlist.uri.to_owned()),
@@ -279,9 +291,10 @@ fn jump_to_end(app: &mut App) {
   match &app.track_table.context {
     Some(context) => match context {
       TrackTableContext::MyPlaylists => {
-        if let (Some(playlists), Some(selected_playlist_index)) =
-          (&app.playlists, &app.selected_playlist_index)
-        {
+        if let (Some(playlists), Some(selected_playlist_index)) = (
+          &app.playlists.get_results(None),
+          &app.selected_playlist_index,
+        ) {
           if let Some(selected_playlist) = playlists.items.get(selected_playlist_index.to_owned()) {
             let total_tracks = selected_playlist
               .tracks
@@ -291,9 +304,12 @@ fn jump_to_end(app: &mut App) {
               as u32;
 
             if app.large_search_limit < total_tracks {
-              app.playlist_offset = total_tracks - (total_tracks % app.large_search_limit);
+              app.playlist_track_offset = total_tracks - (total_tracks % app.large_search_limit);
               let playlist_id = selected_playlist.id.to_owned();
-              app.dispatch(IoEvent::GetPlaylistTracks(playlist_id, app.playlist_offset));
+              app.dispatch(IoEvent::GetPlaylistTracks(
+                playlist_id,
+                app.playlist_track_offset,
+              ));
             }
           }
         }
@@ -318,8 +334,8 @@ fn on_enter(app: &mut App) {
     Some(context) => match context {
       TrackTableContext::MyPlaylists => {
         if let Some(_track) = tracks.get(*selected_index) {
-          let context_uri = match (&app.active_playlist_index, &app.playlists) {
-            (Some(active_playlist_index), Some(playlists)) => playlists
+          let context_uri = match (&app.active_playlist_index, &app.playlists.get_results(None)) {
+            (Some(active_playlist_index), Some(playlist_page)) => playlist_page
               .items
               .get(active_playlist_index.to_owned())
               .map(|selected_playlist| selected_playlist.uri.to_owned()),
@@ -329,7 +345,7 @@ fn on_enter(app: &mut App) {
           app.dispatch(IoEvent::StartPlayback(
             context_uri,
             None,
-            Some(app.track_table.selected_index + app.playlist_offset as usize),
+            Some(app.track_table.selected_index + app.playlist_track_offset as usize),
           ));
         };
       }
@@ -469,13 +485,19 @@ fn jump_to_start(app: &mut App) {
   match &app.track_table.context {
     Some(context) => match context {
       TrackTableContext::MyPlaylists => {
-        if let (Some(playlists), Some(selected_playlist_index)) =
-          (&app.playlists, &app.selected_playlist_index)
-        {
-          if let Some(selected_playlist) = playlists.items.get(selected_playlist_index.to_owned()) {
-            app.playlist_offset = 0;
+        if let (Some(selected_playlist_index), Some(playlist_page)) = (
+          &app.selected_playlist_index,
+          &app.playlists.get_results(None),
+        ) {
+          if let Some(selected_playlist) =
+            playlist_page.items.get(selected_playlist_index.to_owned())
+          {
+            app.playlist_track_offset = 0;
             let playlist_id = selected_playlist.id.to_owned();
-            app.dispatch(IoEvent::GetPlaylistTracks(playlist_id, app.playlist_offset));
+            app.dispatch(IoEvent::GetPlaylistTracks(
+              playlist_id,
+              app.playlist_track_offset,
+            ));
           }
         }
       }

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,7 +400,7 @@ async fn start_ui(user_config: UserConfig, app: &Arc<Mutex<App>>) -> Result<()> 
     // Delay spotify request until first render, will have the effect of improving
     // startup speed
     if is_first_render {
-      app.dispatch(IoEvent::GetPlaylists);
+      app.dispatch(IoEvent::GetPlaylists(None));
       app.dispatch(IoEvent::GetUser);
       app.dispatch(IoEvent::GetCurrentPlayback);
       app.help_docs_size = ui::help::get_help_docs(&app.user_config.keys).len() as u32;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -304,8 +304,8 @@ pub fn draw_playlist_block<B>(f: &mut Frame<B>, app: &App, layout_chunk: Rect)
 where
   B: Backend,
 {
-  let playlist_items = match &app.playlists {
-    Some(p) => p.items.iter().map(|item| item.name.to_owned()).collect(),
+  let playlist_items = match app.playlists.get_results(None) {
+    Some(a) => a.items.iter().map(|item| item.name.to_owned()).collect(),
     None => vec![],
   };
 


### PR DESCRIPTION
Added pagination to playlists. Now playlist pages can be scrolled with usual ctrl+u, ctrl+d keys, so all playlist and not just the 50 first ones will be available.

I'm aware that the author was planning a change in the program's structure that will possibly make this pr useless in the future, but for me the app is quite unusable without all my playlists. Also, unsure if my code is quite rust-like, specifically at the new functions in `ScrollableResultPages`, or in `get_current_user_playlists`, but it gets the job done for now. Listing playlists with `spt list --playlists` still return only the first playlist page. 

Let me tell you what you think about it. Thanks.
