### PR TITLE
Fix analysis bar theme setting not working

### DIFF
--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -13,6 +13,8 @@ const APP_CONFIG_DIR: &str = "spotify-tui";
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct UserTheme {
+  pub analysis_bar: Option<String>,
+  pub analysis_bar_text: Option<String>,
   pub active: Option<String>,
   pub banner: Option<String>,
   pub error_border: Option<String>,
@@ -381,6 +383,8 @@ impl UserConfig {
       };
     }
 
+    to_theme_item!(analysis_bar);
+    to_theme_item!(analysis_bar_text);
     to_theme_item!(active);
     to_theme_item!(banner);
     to_theme_item!(error_border);


### PR DESCRIPTION
When customizing the theme for spotify-tui, I noticed I couldn't customize the analysis bar colors.

At first I thought I was doing something wrong, but looking into the source, it looks like you forgot to properly add the setting to the config. This is what I've fixed in this quick fix.