### PR TITLE
Showing release year on search result listings and artist pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 
+- Show year of album `release_date` in Search panes and on Artist album panes [#1024](https://github.com/Rigellute/spotify-tui/pull/1024)
 - Show `album_type` in Search panes [#868](https://github.com/Rigellute/spotify-tui/pull/868)
 - Add option to set window title to "spt - Spotify TUI" on startup [#844](https://github.com/Rigellute/spotify-tui/pull/844)
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -470,11 +470,17 @@ where
               album_artist.push_str(&app.user_config.padded_liked_icon());
             }
           }
+
+          let end_index = item.release_date.as_deref().unwrap().find("-").unwrap_or(item.release_date.as_deref().unwrap().len());
+          let album_release_year = item.release_date.as_deref().unwrap().get(0..end_index).unwrap();
+
+          let album_type_and_release_year = item.album_type.as_deref().unwrap_or("unknown").to_owned() + ", " + album_release_year;
+
           album_artist.push_str(&format!(
             "{} - {} ({})",
             item.name.to_owned(),
             create_artist_string(&item.artists),
-            item.album_type.as_deref().unwrap_or("unknown")
+            album_type_and_release_year
           ));
           album_artist
         })
@@ -1238,11 +1244,17 @@ where
             album_artist.push_str(&app.user_config.padded_liked_icon());
           }
         }
+
+        let end_index = item.release_date.as_deref().unwrap().find("-").unwrap_or(item.release_date.as_deref().unwrap().len());
+        let album_release_year = item.release_date.as_deref().unwrap().get(0..end_index).unwrap();
+
+        let album_type_and_release_year = item.album_type.as_deref().unwrap_or("unknown").to_owned() + ", " + album_release_year;
+
         album_artist.push_str(&format!(
           "{} - {} ({})",
           item.name.to_owned(),
           create_artist_string(&item.artists),
-          item.album_type.as_deref().unwrap_or("unknown")
+          album_type_and_release_year
         ));
         album_artist
       })

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -21,7 +21,7 @@ use tui::{
   Frame,
 };
 use util::{
-  create_artist_string, display_track_progress, get_artist_highlight_state, get_color,
+  create_artist_string, create_album_type_and_release_year_string, display_track_progress, get_artist_highlight_state, get_color,
   get_percentage_width, get_search_results_highlight_state, get_track_progress_percentage,
   millis_to_minutes, BASIC_VIEW_HEIGHT, SMALL_TERMINAL_WIDTH,
 };
@@ -471,16 +471,11 @@ where
             }
           }
 
-          let end_index = item.release_date.as_deref().unwrap().find("-").unwrap_or(item.release_date.as_deref().unwrap().len());
-          let album_release_year = item.release_date.as_deref().unwrap().get(0..end_index).unwrap();
-
-          let album_type_and_release_year = item.album_type.as_deref().unwrap_or("unknown").to_owned() + ", " + album_release_year;
-
           album_artist.push_str(&format!(
             "{} - {} ({})",
             item.name.to_owned(),
             create_artist_string(&item.artists),
-            album_type_and_release_year
+            create_album_type_and_release_year_string(item)
           ));
           album_artist
         })
@@ -1245,16 +1240,11 @@ where
           }
         }
 
-        let end_index = item.release_date.as_deref().unwrap().find("-").unwrap_or(item.release_date.as_deref().unwrap().len());
-        let album_release_year = item.release_date.as_deref().unwrap().get(0..end_index).unwrap();
-
-        let album_type_and_release_year = item.album_type.as_deref().unwrap_or("unknown").to_owned() + ", " + album_release_year;
-
         album_artist.push_str(&format!(
           "{} - {} ({})",
           item.name.to_owned(),
           create_artist_string(&item.artists),
-          album_type_and_release_year
+          create_album_type_and_release_year_string(item)
         ));
         album_artist
       })

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -1,6 +1,7 @@
 use super::super::app::{ActiveBlock, App, ArtistBlock, SearchResultBlock};
 use crate::user_config::Theme;
 use rspotify::model::artist::SimplifiedArtist;
+use rspotify::model::album::SimplifiedAlbum;
 use tui::style::Style;
 
 pub const BASIC_VIEW_HEIGHT: u16 = 6;
@@ -45,6 +46,13 @@ pub fn create_artist_string(artists: &[SimplifiedArtist]) -> String {
     .map(|artist| artist.name.to_string())
     .collect::<Vec<String>>()
     .join(", ")
+}
+
+pub fn create_album_type_and_release_year_string(album_item: &SimplifiedAlbum) -> String {
+  let end_index = album_item.release_date.as_deref().unwrap().find("-").unwrap_or(album_item.release_date.as_deref().unwrap().len());
+  let album_release_year = album_item.release_date.as_deref().unwrap().get(0..end_index).unwrap();
+
+  album_item.album_type.as_deref().unwrap_or("unknown").to_owned() + ", " + album_release_year
 }
 
 pub fn millis_to_minutes(millis: u128) -> String {

--- a/src/ui/util.rs
+++ b/src/ui/util.rs
@@ -49,8 +49,9 @@ pub fn create_artist_string(artists: &[SimplifiedArtist]) -> String {
 }
 
 pub fn create_album_type_and_release_year_string(album_item: &SimplifiedAlbum) -> String {
-  let end_index = album_item.release_date.as_deref().unwrap().find("-").unwrap_or(album_item.release_date.as_deref().unwrap().len());
-  let album_release_year = album_item.release_date.as_deref().unwrap().get(0..end_index).unwrap();
+  // No matter the release_date_precision, release_date should always start with a four-digit string of the year (YYYY[-MM[-DD]]).
+  // Getting those first four letters/digits should always work.
+  let album_release_year = album_item.release_date.as_deref().unwrap().get(0..4).unwrap();
 
   album_item.album_type.as_deref().unwrap_or("unknown").to_owned() + ", " + album_release_year
 }


### PR DESCRIPTION
I was missing a “Release Year” info on search result and artist pages, which would help me decide what release from an artist I am looking for.

When I forked this, I noticed, that @jackson15j recently had [already done something similar with album _types_](https://github.com/Rigellute/spotify-tui/pull/869) (which I also greatly appreciate). So I build my solution on top of _that_.

Hope you’ll find this worthwhile, too, @Rigellute.

On smaller screens and/or with long album titles, all this new info – especially this new “release year” addition – might not show, because it’s _appended_ to the release’s name (and hence will be cut off). But I still found this to be useful for a lot of artists and result pages.