### PR TITLE
API callback listener use 127.0.0.1 instead of localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ But here they are again:
 1. Click `Create an app`
     - You now can see your `Client ID` and `Client Secret`
 1. Now click `Edit Settings`
-1. Add `http://localhost:8888/callback` to the Redirect URIs
+1. Add `http://127.0.0.1:8888/callback` to the Redirect URIs
 1. Scroll down and click `Save`
 1. You are now ready to authenticate with Spotify!
 1. Go back to the terminal
@@ -177,7 +177,7 @@ But here they are again:
 1. Enter your `Client Secret`
 1. Press enter to confirm the default port (8888) or enter a custom port
 1. You will be redirected to an official Spotify webpage to ask you for permissions.
-1. After accepting the permissions, you'll be redirected to localhost. If all goes well, the redirect URL will be parsed automatically and now you're done. If the local webserver fails for some reason you'll be redirected to a blank webpage that might say something like "Connection Refused" since no server is running. Regardless, copy the URL and paste into the prompt in the terminal.
+1. After accepting the permissions, you'll be redirected to 127.0.0.1. If all goes well, the redirect URL will be parsed automatically and now you're done. If the local webserver fails for some reason you'll be redirected to a blank webpage that might say something like "Connection Refused" since no server is running. Regardless, copy the URL and paste into the prompt in the terminal.
 
 And now you are ready to use the `spotify-tui` 🎉
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,7 +38,7 @@ impl ClientConfig {
   }
 
   pub fn get_redirect_uri(&self) -> String {
-    format!("http://localhost:{}/callback", self.get_port())
+    format!("http://127.0.0.1:{}/callback", self.get_port())
   }
 
   pub fn get_port(&self) -> u16 {
@@ -115,7 +115,7 @@ impl ClientConfig {
         "Click `Create a Client ID` and create an app",
         "Now click `Edit Settings`",
         &format!(
-          "Add `http://localhost:{}/callback` to the Redirect URIs",
+          "Add `http://127.0.0.1:{}/callback` to the Redirect URIs",
           DEFAULT_PORT
         ),
         "You are now ready to authenticate with Spotify!",


### PR DESCRIPTION
R.I.P. spotify-tui :sob: 

Spotify client apps now require HTTPS except for localhost callback listeners, but it only recognizes `127.0.0.1` and not `localhost`.

This updates the instructions and callback reference.

Resolves #1150 