### PR TITLE
Change redirect URI from localhost to 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ But here they are again:
 1. Click `Create an app`
     - You now can see your `Client ID` and `Client Secret`
 1. Now click `Edit Settings`
-1. Add `http://localhost:8888/callback` to the Redirect URIs
+1. Add `http://127.0.0.1:8888/callback` to the Redirect URIs
 1. Scroll down and click `Save`
 1. You are now ready to authenticate with Spotify!
 1. Go back to the terminal

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,7 +38,7 @@ impl ClientConfig {
   }
 
   pub fn get_redirect_uri(&self) -> String {
-    format!("http://localhost:{}/callback", self.get_port())
+    format!("http://127.0.0.1:{}/callback", self.get_port())
   }
 
   pub fn get_port(&self) -> u16 {
@@ -115,7 +115,7 @@ impl ClientConfig {
         "Click `Create a Client ID` and create an app",
         "Now click `Edit Settings`",
         &format!(
-          "Add `http://localhost:{}/callback` to the Redirect URIs",
+          "Add `http://127.0.0.1:{}/callback` to the Redirect URIs",
           DEFAULT_PORT
         ),
         "You are now ready to authenticate with Spotify!",


### PR DESCRIPTION
Updated the redirect URI to use 127.0.0.1 instead of localhost for better compatibility and consistency with IP-based configurations.